### PR TITLE
Reduce Guava use

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/HttpHeader.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpHeader.java
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableList;
-
 import java.util.List;
 import java.util.Objects;
 
@@ -44,7 +42,7 @@ public final class HttpHeader {
             throw new IllegalArgumentException("must give at least one value");
         }
 
-        return new HttpHeader(requireNonNull(name), ImmutableList.copyOf(values));
+        return new HttpHeader(requireNonNull(name), List.of(values));
     }
 
     private HttpHeader(String name, List<String> values) {

--- a/components/api/src/main/java/com/hotels/styx/api/HttpHeaders.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpHeaders.java
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 
@@ -57,7 +55,7 @@ public final class HttpHeaders implements Iterable<HttpHeader> {
      * @return header names
      */
     public Set<String> names() {
-        return ImmutableSet.copyOf(nettyHeaders.names());
+        return nettyHeaders.names();
     }
 
     /**
@@ -80,7 +78,7 @@ public final class HttpHeaders implements Iterable<HttpHeader> {
      * are found
      */
     public List<String> getAll(CharSequence name) {
-        return ImmutableList.copyOf(nettyHeaders.getAll(name));
+        return nettyHeaders.getAll(name);
     }
 
     /**

--- a/components/api/src/main/java/com/hotels/styx/api/HttpMethod.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpMethod.java
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableSet;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -38,7 +36,7 @@ public final class HttpMethod {
     public static final HttpMethod TRACE = new HttpMethod("TRACE");
     public static final HttpMethod CONNECT = new HttpMethod("CONNECT");
 
-    public static final Set<HttpMethod> METHODS = ImmutableSet.of(
+    public static final Set<HttpMethod> METHODS = Set.of(
             OPTIONS,
             GET,
             HEAD,

--- a/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpRequest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableSet;
 import reactor.core.publisher.Flux;
 
 import java.nio.charset.Charset;
@@ -653,7 +652,7 @@ public class HttpRequest implements HttpMessage {
         }
 
         private static <T> Set<T> toSet(Collection<T> collection) {
-            return collection instanceof Set ? (Set<T>) collection : ImmutableSet.copyOf(collection);
+            return collection instanceof Set ? (Set<T>) collection : Set.copyOf(collection);
         }
 
         /**

--- a/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpResponse.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableSet;
 import reactor.core.publisher.Flux;
 
 import java.nio.charset.Charset;
@@ -473,7 +472,7 @@ public class HttpResponse implements HttpMessage {
         }
 
         private static <T> Set<T> toSet(Collection<T> collection) {
-            return collection instanceof Set ? (Set<T>) collection : ImmutableSet.copyOf(collection);
+            return collection instanceof Set ? (Set<T>) collection : Set.copyOf(collection);
         }
 
         /**

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpRequest.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpRequest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableSet;
 import reactor.core.publisher.Flux;
 
 import java.util.Collection;
@@ -963,7 +962,7 @@ public class LiveHttpRequest implements LiveHttpMessage {
         }
 
         private static <T> Set<T> toSet(Collection<T> collection) {
-            return collection instanceof Set ? (Set<T>) collection : ImmutableSet.copyOf(collection);
+            return collection instanceof Set ? (Set<T>) collection : Set.copyOf(collection);
         }
 
         /**

--- a/components/api/src/main/java/com/hotels/styx/api/LiveHttpResponse.java
+++ b/components/api/src/main/java/com/hotels/styx/api/LiveHttpResponse.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableSet;
 import reactor.core.publisher.Flux;
 
 import java.util.Collection;
@@ -760,7 +759,7 @@ public class LiveHttpResponse implements LiveHttpMessage {
         }
 
         private static <T> Set<T> toSet(Collection<T> collection) {
-            return collection instanceof Set ? (Set<T>) collection : ImmutableSet.copyOf(collection);
+            return collection instanceof Set ? (Set<T>) collection : Set.copyOf(collection);
         }
 
         /**

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/BackendService.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/BackendService.java
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.api.extension.service;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.hotels.styx.api.Id;
 import com.hotels.styx.api.Identifiable;
 import com.hotels.styx.api.extension.Origin;
@@ -86,7 +84,7 @@ public final class BackendService implements Identifiable {
         this.id = requireNonNull(builder.id, "id");
         this.path = requireNonNull(builder.path, "path");
         this.connectionPoolSettings = requireNonNull(builder.connectionPoolSettings);
-        this.origins = ImmutableSet.copyOf(builder.origins);
+        this.origins = Set.copyOf(builder.origins);
         this.healthCheckConfig = nullIfDisabled(builder.healthCheckConfig);
         this.stickySessionConfig = requireNonNull(builder.stickySessionConfig);
         this.rewrites = requireNonNull(builder.rewrites);
@@ -362,7 +360,7 @@ public final class BackendService implements Identifiable {
          * @return this builder
          */
         public Builder origins(Origin... origins) {
-            return origins(ImmutableSet.copyOf(origins));
+            return origins(Set.of(origins));
         }
 
         /**
@@ -382,7 +380,7 @@ public final class BackendService implements Identifiable {
          * @return this builder
          */
         public Builder rewrites(List<RewriteConfig> rewriteConfigs) {
-            this.rewrites = ImmutableList.copyOf(rewriteConfigs);
+            this.rewrites = List.copyOf(rewriteConfigs);
             return this;
         }
 

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/RewriteConfig.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/RewriteConfig.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api.extension.service;
 
-import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +24,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.Integer.parseInt;
-import static java.util.Arrays.asList;
 import static java.util.regex.Pattern.compile;
 
 /**
@@ -141,7 +139,7 @@ public class RewriteConfig implements RewriteRule {
         }
 
         private static List<String> literals(String replacement) {
-            return ImmutableList.copyOf(asList(replacement.split(REGEX)));
+            return List.of(replacement.split(REGEX));
         }
 
         private static List<Integer> placeholderNumbers(String replacement) {
@@ -154,7 +152,7 @@ public class RewriteConfig implements RewriteRule {
                 placeholderNumbers.add(placeholderNumber(nextGroup));
             }
 
-            return ImmutableList.copyOf(placeholderNumbers);
+            return List.copyOf(placeholderNumbers);
         }
 
         private static int placeholderNumber(String nextGroup) {

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/TlsSettings.java
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.api.extension.service;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 
 import java.io.File;
 import java.util.Arrays;
@@ -55,8 +53,8 @@ public class TlsSettings {
         this.additionalCerts = builder.additionalCerts;
         this.trustStorePath = builder.trustStorePath;
         this.trustStorePassword = toCharArray(builder.trustStorePassword);
-        this.protocols = ImmutableList.copyOf(builder.protocols);
-        this.cipherSuites = ImmutableList.copyOf(builder.cipherSuites);
+        this.protocols = List.copyOf(builder.protocols);
+        this.cipherSuites = List.copyOf(builder.cipherSuites);
         this.sendSni = builder.sendSni;
         this.sniHost = Optional.ofNullable(builder.sniHost);
     }
@@ -223,7 +221,7 @@ public class TlsSettings {
          * @return
          */
         public Builder additionalCerts(Certificate... certificates) {
-            this.additionalCerts = Sets.newHashSet(certificates);
+            this.additionalCerts = Set.of(certificates);
             return this;
         }
 

--- a/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
+++ b/components/api/src/main/java/com/hotels/styx/api/extension/service/spi/AbstractStyxService.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api.extension.service.spi;
 
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 import org.slf4j.Logger;
@@ -112,7 +111,7 @@ public abstract class AbstractStyxService implements StyxService {
 
     @Override
     public Map<String, HttpHandler> adminInterfaceHandlers() {
-        return ImmutableMap.of("status", (request, context) -> Eventual.of(
+        return Map.of("status", (request, context) -> Eventual.of(
                 response(OK)
                         .addHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .body(format("{ name: \"%s\" status: \"%s\" }", name, status), UTF_8)

--- a/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/HttpRequestTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -23,12 +22,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.hotels.styx.api.HttpHeader.header;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH;
-import static com.hotels.styx.api.HttpHeaderNames.COOKIE;
 import static com.hotels.styx.api.HttpHeaderNames.HOST;
 import static com.hotels.styx.api.HttpMethod.DELETE;
 import static com.hotels.styx.api.HttpMethod.GET;
@@ -305,7 +304,7 @@ public class HttpRequestTest {
 
         assertThat(req.queryParamNames(), containsInAnyOrder("foo", "abc"));
 
-        assertThat(req.queryParams(), isMap(ImmutableMap.of(
+        assertThat(req.queryParams(), isMap(Map.of(
                 "foo", asList("bar", "hello"),
                 "abc", singletonList("def")
         )));

--- a/components/api/src/test/java/com/hotels/styx/api/LiveHttpRequestTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/LiveHttpRequestTest.java
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -24,6 +22,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
@@ -208,7 +208,7 @@ public class LiveHttpRequestTest {
 
         assertThat(req.queryParamNames(), containsInAnyOrder("foo", "abc"));
 
-        assertThat(req.queryParams(), isMap(ImmutableMap.of(
+        assertThat(req.queryParams(), isMap(Map.of(
                 "foo", asList("bar", "hello"),
                 "abc", singletonList("def")
         )));
@@ -516,7 +516,7 @@ public class LiveHttpRequestTest {
     public void transformsCookiesViaList() {
         LiveHttpRequest request = LiveHttpRequest.get("/").addCookies(requestCookie("cookie", "xyz010")).build()
                 .newBuilder()
-                .cookies(ImmutableList.of(requestCookie("cookie", "xyz202")))
+                .cookies(List.of(requestCookie("cookie", "xyz202")))
                 .build();
 
         assertEquals(request.cookie("cookie"), Optional.of(requestCookie("cookie", "xyz202")));
@@ -536,7 +536,7 @@ public class LiveHttpRequestTest {
     public void transformsByAddingCookiesList() {
         LiveHttpRequest request = LiveHttpRequest.get("/").build()
                 .newBuilder()
-                .addCookies(ImmutableList.of(requestCookie("cookie", "xyz202")))
+                .addCookies(List.of(requestCookie("cookie", "xyz202")))
                 .build();
 
         assertEquals(request.cookie("cookie"), Optional.of(requestCookie("cookie", "xyz202")));
@@ -556,7 +556,7 @@ public class LiveHttpRequestTest {
     public void transformsByRemovingCookieList() {
         LiveHttpRequest request = LiveHttpRequest.get("/").addCookies(requestCookie("cookie", "xyz202")).build()
                 .newBuilder()
-                .removeCookies(ImmutableList.of("cookie"))
+                .removeCookies(List.of("cookie"))
                 .build();
 
         assertEquals(request.cookie("cookie"), Optional.empty());

--- a/components/api/src/test/java/com/hotels/styx/api/LiveHttpResponseTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/LiveHttpResponseTest.java
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableList;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -24,8 +22,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
@@ -381,7 +379,7 @@ public class LiveHttpResponseTest {
     public void transformsWithCookieList() {
         LiveHttpResponse response = response().build()
                 .newBuilder()
-                .cookies(ImmutableList.of(responseCookie("x", "y").build()))
+                .cookies(List.of(responseCookie("x", "y").build()))
                 .build();
 
         assertEquals(response.cookie("x"), Optional.of(responseCookie("x", "y").build()));
@@ -401,7 +399,7 @@ public class LiveHttpResponseTest {
     public void transformerAddsCookiesList() {
         LiveHttpResponse response = response().build()
                 .newBuilder()
-                .addCookies(ImmutableList.of(responseCookie("x", "y").build()))
+                .addCookies(List.of(responseCookie("x", "y").build()))
                 .build();
 
         assertEquals(response.cookie("x"), Optional.of(responseCookie("x", "y").build()));
@@ -410,7 +408,7 @@ public class LiveHttpResponseTest {
     @Test
     public void transformerRemovesCookies() {
         LiveHttpResponse response = response()
-                .addCookies(ImmutableList.of(responseCookie("x", "y").build()))
+                .addCookies(List.of(responseCookie("x", "y").build()))
                 .build()
                 .newBuilder()
                 .removeCookies("x")
@@ -422,10 +420,10 @@ public class LiveHttpResponseTest {
     @Test
     public void transformerRemovesCookiesWithList() {
         LiveHttpResponse response = response()
-                .addCookies(ImmutableList.of(responseCookie("x", "y").build()))
+                .addCookies(List.of(responseCookie("x", "y").build()))
                 .build()
                 .newBuilder()
-                .removeCookies(ImmutableList.of("x"))
+                .removeCookies(List.of("x"))
                 .build();
 
         assertEquals(response.cookie("x"), Optional.empty());

--- a/components/api/src/test/java/com/hotels/styx/api/RequestCookieTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/RequestCookieTest.java
@@ -15,8 +15,9 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static com.hotels.styx.api.RequestCookie.encode;
 import static com.hotels.styx.api.RequestCookie.requestCookie;
@@ -43,7 +44,7 @@ public class RequestCookieTest {
 
     @Test
     public void doesNotEncodeDuplicateCookies() {
-        String encoded = encode(ImmutableList.of(
+        String encoded = encode(List.of(
                 requestCookie("foo", "bar"),
                 requestCookie("bar", "foo"),
                 requestCookie("foo", "asjdfksdajf")

--- a/components/api/src/test/java/com/hotels/styx/api/UrlTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/UrlTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -23,6 +22,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.URL;
 import java.nio.charset.CharacterCodingException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -36,7 +36,6 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UrlTest {
     @Test
@@ -118,7 +117,7 @@ public class UrlTest {
 
         assertThat(url.queryParamNames(), containsInAnyOrder("foo", "abc"));
 
-        assertThat(url.queryParams(), isMap(ImmutableMap.of(
+        assertThat(url.queryParams(), isMap(Map.of(
                 "foo", asList("bar", "hello"),
                 "abc", singletonList("def")
         )));

--- a/components/api/src/test/java/com/hotels/styx/api/extension/service/spi/AbstractRegistryTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/extension/service/spi/AbstractRegistryTest.java
@@ -15,13 +15,13 @@
  */
 package com.hotels.styx.api.extension.service.spi;
 
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.Id;
 import com.hotels.styx.api.Identifiable;
 import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.extension.service.BackendService;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
@@ -49,7 +49,7 @@ public class AbstractRegistryTest {
         registry.addListener(listener1);
         registry.addListener(listener2);
 
-        registry.set(ImmutableList.of(idObject("a", "1"), idObject("b", "2")));
+        registry.set(List.of(idObject("a", "1"), idObject("b", "2")));
 
         Registry.Changes<IdObject> changes = changeSet()
                 .added(idObject("a", "1"), idObject("b", "2"))
@@ -62,7 +62,7 @@ public class AbstractRegistryTest {
     @Test
     public void notifiesNewListenersImmediately() {
         TestRegistry registry = new TestRegistry();
-        registry.set(ImmutableList.of(idObject("a", "1"), idObject("b", "2")));
+        registry.set(List.of(idObject("a", "1"), idObject("b", "2")));
 
         AbstractRegistry.ChangeListener<IdObject> listener1 = mock(AbstractRegistry.ChangeListener.class);
         registry.addListener(listener1);
@@ -81,9 +81,9 @@ public class AbstractRegistryTest {
         AbstractRegistry.ChangeListener<IdObject> listener1 = mock(AbstractRegistry.ChangeListener.class);
         registry.addListener(listener1);
 
-        registry.set(ImmutableList.of(idObject("a", "1")));
+        registry.set(List.of(idObject("a", "1")));
 
-        registry.set(ImmutableList.of(idObject("a", "2"), idObject("b", "2")));
+        registry.set(List.of(idObject("a", "2"), idObject("b", "2")));
         verify(listener1).onChange(eq(changeSet()
                 .added(idObject("b", "2"))
                 .updated(idObject("a", "2"))
@@ -98,11 +98,11 @@ public class AbstractRegistryTest {
         registry.addListener(listener1);
         verify(listener1).onChange(any(Registry.Changes.class));
 
-        registry.set(ImmutableList.of(idObject("a", "1"), idObject("b", "2")));
+        registry.set(List.of(idObject("a", "1"), idObject("b", "2")));
         verify(listener1, times(2)).onChange(any(Registry.Changes.class));
 
         // Does not change:
-        registry.set(ImmutableList.of(idObject("a", "1"), idObject("b", "2")));
+        registry.set(List.of(idObject("a", "1"), idObject("b", "2")));
         verifyNoMoreInteractions(listener1);
     }
 
@@ -115,9 +115,9 @@ public class AbstractRegistryTest {
         registry.addListener(listener1);
         registry.addListener(listener2);
 
-        registry.set(ImmutableList.of(idObject("a", "1"), idObject("b", "2")));
+        registry.set(List.of(idObject("a", "1"), idObject("b", "2")));
 
-        registry.set(ImmutableList.of(idObject("a", "1")));
+        registry.set(List.of(idObject("a", "1")));
 
         verify(listener1).onChange(changeSet().removed(idObject("b", "2")).build());
         verify(listener2).onChange(changeSet().removed(idObject("b", "2")).build());
@@ -133,14 +133,14 @@ public class AbstractRegistryTest {
         registry.addListener(listener1);
         registry.addListener(listener2);
 
-        registry.set(ImmutableList.of(idObject("a", "1"), idObject("b", "2")));
+        registry.set(List.of(idObject("a", "1"), idObject("b", "2")));
 
         verify(listener1).onChange(changeSet().added(idObject("a", "1"), idObject("b", "2")).build());
         verify(listener2).onChange(changeSet().added(idObject("a", "1"), idObject("b", "2")).build());
 
         registry.removeListener(listener2);
 
-        registry.set(ImmutableList.of(idObject("a", "1")));
+        registry.set(List.of(idObject("a", "1")));
         verify(listener1).onChange(changeSet().removed(idObject("b", "2")).build());
         verify(listener2, never()).onChange(changeSet().removed(idObject("b", "2")).build());
 

--- a/components/api/src/test/java/com/hotels/styx/api/matchers/HttpHeadersMatcher.java
+++ b/components/api/src/test/java/com/hotels/styx/api/matchers/HttpHeadersMatcher.java
@@ -23,7 +23,6 @@ import org.hamcrest.core.IsCollectionContaining;
 
 import java.util.List;
 
-import static com.google.common.collect.Iterables.all;
 import static com.hotels.styx.api.matchers.HeaderMatcher.header;
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
@@ -41,7 +40,7 @@ public class HttpHeadersMatcher extends TypeSafeMatcher<Iterable<HttpHeader>> {
                 header("Cache-Control", "no-cache,must-revalidate,no-store")));
     }
 
-    @SuppressWarnings ("unchecked")
+    @SuppressWarnings("unchecked")
     public static Matcher<Iterable<HttpHeader>> hasHeaders(Matcher<HttpHeader>... matchers) {
         return new HttpHeadersMatcher(asList(matchers));
     }
@@ -52,7 +51,8 @@ public class HttpHeadersMatcher extends TypeSafeMatcher<Iterable<HttpHeader>> {
 
     @Override
     public boolean matchesSafely(Iterable<HttpHeader> actual) {
-        return all(matchers, elementMatcher -> new IsCollectionContaining<>(elementMatcher).matches(actual));
+        return matchers.stream().allMatch(elementMatcher ->
+                new IsCollectionContaining<>(elementMatcher).matches(actual));
     }
 
     @Override

--- a/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
@@ -16,8 +16,6 @@
 package com.hotels.styx.client;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.hotels.styx.api.Eventual;
@@ -46,6 +44,7 @@ import org.slf4j.Logger;
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.Closeable;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -129,7 +128,7 @@ public final class OriginsInventory
 
     @Override
     public String getApplicationId() {
-        return  appId.toString();
+        return appId.toString();
     }
 
     @Override
@@ -150,7 +149,7 @@ public final class OriginsInventory
 
     @VisibleForTesting
     public void setOrigins(Origin... origins) {
-        setOrigins(ImmutableSet.copyOf(origins));
+        setOrigins(Set.of(origins));
     }
 
     @Override
@@ -283,7 +282,7 @@ public final class OriginsInventory
     private void handleCloseEvent() {
         if (closed.compareAndSet(false, true)) {
             origins.values().forEach(host -> removeMonitoredEndpoint(host.origin.id()));
-            this.origins = ImmutableMap.of();
+            this.origins = Map.of();
             notifyStateChange();
             eventBus.unregister(this);
         }
@@ -537,7 +536,7 @@ public final class OriginsInventory
         }
 
         public Builder initialOrigins(Set<Origin> origins) {
-            this.initialOrigins = ImmutableSet.copyOf(origins);
+            this.initialOrigins = Set.copyOf(origins);
             return this;
         }
 
@@ -581,7 +580,7 @@ public final class OriginsInventory
     }
 
     private class OriginChanges {
-        ImmutableMap.Builder<Id, MonitoredOrigin> monitoredOrigins = ImmutableMap.builder();
+        Map<Id, MonitoredOrigin> monitoredOrigins = new HashMap<>();
         AtomicBoolean changed = new AtomicBoolean(false);
 
         void addOrReplaceOrigin(Id originId, MonitoredOrigin origin) {
@@ -602,7 +601,7 @@ public final class OriginsInventory
         }
 
         Map<Id, MonitoredOrigin> updatedOrigins() {
-            return monitoredOrigins.build();
+            return Map.copyOf(monitoredOrigins);
         }
     }
 }

--- a/components/client/src/main/java/com/hotels/styx/client/RewriteRuleset.java
+++ b/components/client/src/main/java/com/hotels/styx/client/RewriteRuleset.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client;
 
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.Url;
 import com.hotels.styx.api.extension.service.RewriteRule;
@@ -37,7 +36,7 @@ public class RewriteRuleset {
      * @param rewriteRules rewrite rules
      */
     public RewriteRuleset(List<RewriteRule> rewriteRules) {
-        this.rewriteRules = ImmutableList.copyOf(rewriteRules);
+        this.rewriteRules = List.copyOf(rewriteRules);
     }
 
     /**

--- a/components/client/src/main/java/com/hotels/styx/client/StyxBackendServiceClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxBackendServiceClient.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client;
 
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpResponseStatus;
 import com.hotels.styx.api.Id;
@@ -44,7 +43,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH;
 import static com.hotels.styx.api.HttpHeaderNames.TRANSFER_ENCODING;
 import static com.hotels.styx.api.HttpMethod.HEAD;
@@ -142,7 +140,7 @@ public final class StyxBackendServiceClient implements BackendServiceClient {
         Optional<RemoteHost> remoteHost = selectOrigin(request);
         if (remoteHost.isPresent()) {
             RemoteHost host = remoteHost.get();
-            List<RemoteHost> newPreviousOrigins = newArrayList(previousOrigins);
+            List<RemoteHost> newPreviousOrigins = new ArrayList<>(previousOrigins);
             newPreviousOrigins.add(remoteHost.get());
 
             return ResponseEventListener.from(
@@ -381,7 +379,7 @@ public final class StyxBackendServiceClient implements BackendServiceClient {
         }
 
         public Builder rewriteRules(List<? extends RewriteRule> rewriteRules) {
-            this.rewriteRules = ImmutableList.copyOf(rewriteRules);
+            this.rewriteRules = List.copyOf(rewriteRules);
             return this;
         }
 

--- a/components/client/src/main/java/com/hotels/styx/client/healthcheck/monitors/ScheduledOriginHealthStatusMonitor.java
+++ b/components/client/src/main/java/com/hotels/styx/client/healthcheck/monitors/ScheduledOriginHealthStatusMonitor.java
@@ -30,7 +30,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static com.google.common.collect.ImmutableSet.copyOf;
 import static com.hotels.styx.api.extension.service.spi.StyxServiceStatus.RUNNING;
 import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
@@ -76,7 +75,7 @@ public class ScheduledOriginHealthStatusMonitor extends AbstractStyxService impl
 
     @VisibleForTesting
     OriginHealthStatusMonitor monitor(Origin... origins) {
-        return monitor(copyOf(origins));
+        return monitor(Set.of(origins));
     }
 
     @Override

--- a/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/RoundRobinStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/RoundRobinStrategy.java
@@ -16,19 +16,19 @@
 package com.hotels.styx.client.loadbalancing.strategies;
 
 import com.hotels.styx.api.Environment;
+import com.hotels.styx.api.configuration.Configuration;
 import com.hotels.styx.api.extension.ActiveOrigins;
 import com.hotels.styx.api.extension.OriginsSnapshot;
 import com.hotels.styx.api.extension.RemoteHost;
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancer;
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancerFactory;
-import com.hotels.styx.api.configuration.Configuration;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.google.common.collect.Lists.newArrayList;
+import static com.hotels.styx.javaconvenience.UtilKt.iterableToList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -48,12 +48,12 @@ import static java.util.Objects.requireNonNull;
 public class RoundRobinStrategy implements LoadBalancer {
 
     private ActiveOrigins activeOrigins;
-    private final AtomicReference<ArrayList<RemoteHost>> origins;
+    private final AtomicReference<List<RemoteHost>> origins;
     private final AtomicInteger index = new AtomicInteger(0);
 
     public RoundRobinStrategy(ActiveOrigins activeOrigins, Iterable<RemoteHost> initialOrigins) {
         this.activeOrigins = requireNonNull(activeOrigins);
-        this.origins = new AtomicReference<>(new ArrayList<>(newArrayList(initialOrigins)));
+        this.origins = new AtomicReference<>(iterableToList(initialOrigins));
     }
 
     /**
@@ -68,7 +68,7 @@ public class RoundRobinStrategy implements LoadBalancer {
 
     @Override
     public Optional<RemoteHost> choose(Preferences preferences) {
-        ArrayList<RemoteHost> remoteHosts = origins.get();
+        List<RemoteHost> remoteHosts = origins.get();
         if (remoteHosts == null || remoteHosts.isEmpty()) {
             return Optional.empty();
         } else {
@@ -78,7 +78,7 @@ public class RoundRobinStrategy implements LoadBalancer {
 
     @Override
     public void originsChanged(OriginsSnapshot snapshot) {
-        origins.set(newArrayList(activeOrigins.snapshot()));
+        origins.set(iterableToList(activeOrigins.snapshot()));
     }
 
     @Override

--- a/components/client/src/main/java/com/hotels/styx/client/retry/RetryNTimes.java
+++ b/components/client/src/main/java/com/hotels/styx/client/retry/RetryNTimes.java
@@ -22,7 +22,7 @@ import com.hotels.styx.api.extension.retrypolicy.spi.RetryPolicy;
 
 import java.util.Optional;
 
-import static com.google.common.collect.Sets.newHashSet;
+import static com.hotels.styx.javaconvenience.UtilKt.iterableToSet;
 
 /**
  * A {@link RetryPolicy} that tries a configurable <code>maxAttempts</code>.
@@ -43,7 +43,7 @@ public class RetryNTimes extends AbstractRetryPolicy {
             @Override
             public Optional<RemoteHost> nextOrigin() {
                 return loadBalancingStrategy.choose(lbContext)
-                        .filter(nextHost -> !newHashSet(context.previousOrigins()).contains(nextHost));
+                        .filter(nextHost -> !iterableToSet(context.previousOrigins()).contains(nextHost));
             }
 
             @Override

--- a/components/client/src/test/unit/java/com/hotels/styx/client/OriginsInventoryTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/OriginsInventoryTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.hotels.styx.api.MeterRegistry;
 import com.hotels.styx.api.MicrometerRegistry;
@@ -38,6 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static ch.qos.logback.classic.Level.INFO;
 import static com.hotels.styx.api.Id.GENERIC_APP;
@@ -466,8 +466,8 @@ public class OriginsInventoryTest {
         inventory.setOrigins(ORIGIN_1, ORIGIN_2);
         inventory.close();
 
-        verify(monitor).stopMonitoring(eq(ImmutableSet.of(ORIGIN_1)));
-        verify(monitor).stopMonitoring(eq(ImmutableSet.of(ORIGIN_2)));
+        verify(monitor).stopMonitoring(eq(Set.of(ORIGIN_1)));
+        verify(monitor).stopMonitoring(eq(Set.of(ORIGIN_2)));
         assertThat(gaugeValue("generic-app", "app-01"), isAbsent());
         assertThat(gaugeValue("generic-app", "app-02"), isAbsent());
 

--- a/components/client/src/test/unit/java/com/hotels/styx/client/applications/BackendServiceTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/applications/BackendServiceTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static com.google.common.collect.Sets.newHashSet;
 import static com.hotels.styx.api.extension.Origin.newOriginBuilder;
 import static com.hotels.styx.api.extension.service.BackendService.DEFAULT_RESPONSE_TIMEOUT_MILLIS;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BackendServiceTest {
-    Set<Origin> originSet = newHashSet(newOriginBuilder("localhost", 123).build());
+    Set<Origin> originSet = Set.of(newOriginBuilder("localhost", 123).build());
 
     @Test
     public void usesResponseTimeoutOfZeroToIndicateDefaultValue() {

--- a/components/client/src/test/unit/java/com/hotels/styx/client/loadbalancing/strategies/RoundRobinStrategyTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/loadbalancing/strategies/RoundRobinStrategyTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client.loadbalancing.strategies;
 
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.Environment;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.Id;
@@ -28,10 +27,10 @@ import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancer;
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancingMetric;
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancingMetricSupplier;
 import com.hotels.styx.client.connectionpool.stubs.StubConnectionFactory;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.hotels.styx.api.Id.id;
@@ -105,7 +104,7 @@ public class RoundRobinStrategyTest {
         strategy = new RoundRobinStrategy.Factory().create(environment, configuration, new ActiveOrigins() {
             @Override
             public Iterable<RemoteHost> snapshot() {
-                return ImmutableList.of();
+                return List.of();
             }
 
             @Override

--- a/components/client/src/test/unit/java/com/hotels/styx/client/stickysession/StickySessionLoadBalancingStrategyTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/stickysession/StickySessionLoadBalancingStrategyTest.java
@@ -27,9 +27,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.collect.Iterables.getFirst;
 import static com.hotels.styx.api.extension.Origin.newOriginBuilder;
 import static com.hotels.styx.api.extension.RemoteHost.remoteHost;
+import static com.hotels.styx.javaconvenience.UtilKt.first;
 import static java.util.Arrays.asList;
 import static java.util.Collections.EMPTY_LIST;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -52,10 +52,9 @@ public class StickySessionLoadBalancingStrategyTest {
 
     final ActiveOrigins activeOrigins = mock(ActiveOrigins.class);
 
-    final LoadBalancer FALL_BACK_STRATEGY = (context) -> Optional.ofNullable(getFirst(activeOrigins.snapshot(), null));
+    final LoadBalancer FALL_BACK_STRATEGY = (context) -> Optional.ofNullable(first(activeOrigins.snapshot()));
 
     final LoadBalancer strategy = new StickySessionLoadBalancingStrategy(activeOrigins, FALL_BACK_STRATEGY);
-
 
     @Test
     public void selectsThePreferredOrigin() {
@@ -94,7 +93,6 @@ public class StickySessionLoadBalancingStrategyTest {
         Optional<RemoteHost> chosenOne = strategy.choose(lbPreferences(Optional.of(ORIGIN_1.id())));
 
         assertThat(chosenOne, is(Optional.empty()));
-
     }
 
     @Test
@@ -105,7 +103,6 @@ public class StickySessionLoadBalancingStrategyTest {
 
         assertThat(chosenOne, is(Optional.of(ORIGIN_2)));
     }
-
 
     private LoadBalancer.Preferences lbPreferences(Optional<Id> id) {
         return new LoadBalancer.Preferences() {
@@ -120,5 +117,4 @@ public class StickySessionLoadBalancingStrategyTest {
             }
         };
     }
-
 }

--- a/components/common/src/main/java/com/hotels/styx/api/metrics/ScopedMetricRegistry.java
+++ b/components/common/src/main/java/com/hotels/styx/api/metrics/ScopedMetricRegistry.java
@@ -25,11 +25,11 @@ import com.codahale.metrics.MetricRegistryListener;
 import com.codahale.metrics.Timer;
 import com.hotels.styx.api.MetricRegistry;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.SortedSet;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -72,7 +72,7 @@ public class ScopedMetricRegistry implements MetricRegistry {
      * @return the list of scopes this registry is part of
      */
     public List<String> scopes() {
-        List<String> scopes = newArrayList();
+        List<String> scopes = new ArrayList<>();
         if (parent instanceof ScopedMetricRegistry) {
             scopes.addAll(((ScopedMetricRegistry) parent).scopes());
         }

--- a/components/common/src/main/java/com/hotels/styx/common/io/ClasspathResourceIndex.java
+++ b/components/common/src/main/java/com/hotels/styx/common/io/ClasspathResourceIndex.java
@@ -15,19 +15,15 @@
  */
 package com.hotels.styx.common.io;
 
-import com.google.common.collect.Iterators;
 import com.hotels.styx.api.Resource;
+import com.hotels.styx.javaconvenience.UtilKt;
 
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
-import java.util.Iterator;
-import java.util.stream.Stream;
 
-import static java.util.Spliterator.ORDERED;
-import static java.util.Spliterators.spliteratorUnknownSize;
+import static com.hotels.styx.javaconvenience.UtilKt.iteratorToStream;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.StreamSupport.stream;
 
 /**
  * A resource index that scans the class path for the resources.
@@ -47,21 +43,13 @@ public class ClasspathResourceIndex implements ResourceIndex {
         try {
             Enumeration<URL> resources = classLoader.getResources(classpath);
 
-            return enumerationStream(resources)
+            return iteratorToStream(resources.asIterator())
                     .map(url -> resourceIteratorFactory.createIterator(url, classpath, suffix))
-                    .flatMap(ClasspathResourceIndex::iteratorStream)
+                    .flatMap(UtilKt::iteratorToStream)
                     .collect(toList());
 
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private static <T> Stream<T> enumerationStream(Enumeration<T> enumeration) {
-        return iteratorStream(Iterators.forEnumeration(enumeration));
-    }
-
-    private static <T> Stream<T> iteratorStream(Iterator<T> iterator) {
-        return stream(spliteratorUnknownSize(iterator, ORDERED), false);
     }
 }

--- a/components/common/src/main/java/com/hotels/styx/config/schema/AtLeastOneFieldPresenceConstraint.java
+++ b/components/common/src/main/java/com/hotels/styx/config/schema/AtLeastOneFieldPresenceConstraint.java
@@ -16,11 +16,10 @@
 package com.hotels.styx.config.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
+import static com.hotels.styx.javaconvenience.UtilKt.iteratorToList;
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;
@@ -33,7 +32,7 @@ class AtLeastOneFieldPresenceConstraint implements Constraint {
     private final String description;
 
     AtLeastOneFieldPresenceConstraint(String... fieldNames) {
-        this.fieldNames = ImmutableSet.copyOf(fieldNames);
+        this.fieldNames = Set.of(fieldNames);
         this.description = description(fieldNames);
     }
 
@@ -46,7 +45,7 @@ class AtLeastOneFieldPresenceConstraint implements Constraint {
 
     @Override
     public boolean evaluate(Schema schema, JsonNode node) {
-        long fieldsPresent = ImmutableList.copyOf(node.fieldNames())
+        long fieldsPresent = iteratorToList(node.fieldNames())
                 .stream()
                 .filter(fieldNames::contains)
                 .count();

--- a/components/common/src/main/java/com/hotels/styx/config/schema/Schema.java
+++ b/components/common/src/main/java/com/hotels/styx/config/schema/Schema.java
@@ -16,8 +16,6 @@
 package com.hotels.styx.config.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -32,11 +30,13 @@ import static com.hotels.styx.config.schema.SchemaDsl.object;
 import static com.hotels.styx.config.schema.SchemaDsl.optional;
 import static com.hotels.styx.config.schema.SchemaDsl.string;
 import static com.hotels.styx.config.schema.SchemaDsl.union;
+import static com.hotels.styx.javaconvenience.UtilKt.iteratorToList;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static java.util.stream.StreamSupport.stream;
 
 /**
  * Declares a layout and constraints for configuration objects.
@@ -63,7 +63,7 @@ import static java.util.stream.Collectors.toSet;
  * attribute type.
  */
 public class Schema {
-    private final ImmutableList<Constraint> constraints;
+    private final List<Constraint> constraints;
     private final String name;
     private final List<String> fieldNames;
     private final List<Field> fields;
@@ -72,9 +72,9 @@ public class Schema {
 
     private Schema(Builder builder) {
         this.fieldNames = builder.fields.stream().map(Field::name).collect(toList());
-        this.fields = ImmutableList.copyOf(builder.fields);
-        this.optionalFields = ImmutableSet.copyOf(builder.optionalFields);
-        this.constraints = ImmutableList.copyOf(builder.constraints);
+        this.fields = List.copyOf(builder.fields);
+        this.optionalFields = Set.copyOf(builder.optionalFields);
+        this.constraints = List.copyOf(builder.constraints);
         this.ignore = builder.pass;
         this.name = builder.name.length() > 0 ? builder.name : String.join(", ", this.fieldNames);
     }
@@ -139,7 +139,7 @@ public class Schema {
     }
 
     private static void assertNoUnknownFields(String prefix, Schema schema, List<String> fieldsPresent) {
-        Set<String> knownFields = ImmutableSet.copyOf(schema.fieldNames());
+        Set<String> knownFields = Set.copyOf(schema.fieldNames());
 
         fieldsPresent.forEach(name -> {
             if (!knownFields.contains(name)) {
@@ -147,7 +147,6 @@ public class Schema {
             }
         });
     }
-
 
     /**
      * Represents a schema field type.
@@ -435,7 +434,7 @@ public class Schema {
                 }
             });
 
-            assertNoUnknownFields(String.join(".", parents), schema, ImmutableList.copyOf(value.fieldNames()));
+            assertNoUnknownFields(String.join(".", parents), schema, iteratorToList(value.fieldNames()));
         }
 
         @Override

--- a/components/common/src/main/java/com/hotels/styx/config/validator/DocumentFormat.java
+++ b/components/common/src/main/java/com/hotels/styx/config/validator/DocumentFormat.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.config.validator;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.config.schema.InvalidSchemaException;
 import com.hotels.styx.config.schema.Schema;
 import org.slf4j.Logger;
@@ -42,7 +41,7 @@ public class DocumentFormat {
     private static final Logger LOGGER = LoggerFactory.getLogger(DocumentFormat.class);
 
     private final Schema.FieldType root;
-    private final ImmutableMap<String, Schema.FieldType> additionalSchemas;
+    private final Map<String, Schema.FieldType> additionalSchemas;
 
     public void validateObject(JsonNode tree) {
         root.validate(new ArrayList<>(), tree, tree, this.additionalSchemas::get);
@@ -54,7 +53,7 @@ public class DocumentFormat {
 
     private DocumentFormat(Builder builder) {
         this.root = requireNonNull(builder.root);
-        this.additionalSchemas = ImmutableMap.copyOf(builder.schemas);
+        this.additionalSchemas = Map.copyOf(builder.schemas);
     }
 
     /**

--- a/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
+++ b/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
@@ -20,8 +20,10 @@ import kotlin.streams.asStream
 
 /*
  * Note: although written in Kotlin, these convenience methods are intended to be used by Java code.
- * As such, certain language features that make Kotlin development easier will have no benefit in Java (or possibly make things more complicated),
- * for example, extension methods, this-receivers.
+ *
+ * This has the following effects:
+ * - Some functions seem redundant as they wrap a single kotlin function (the kotlin function doesn't exist in Java)
+ * - Some language features that make Kotlin development easier are not used. For example: extension methods, this-receivers.
  */
 
 fun <T> iteratorToList(iterator: Iterator<T>): List<T> = Iterable {
@@ -29,6 +31,16 @@ fun <T> iteratorToList(iterator: Iterator<T>): List<T> = Iterable {
 }.toList()
 
 fun <T> iterableToList(iterable: Iterable<T>): List<T> = iterable.toList()
+
+/**
+ * Preserves iteration order.
+ */
+fun <T> iterableToSet(iterable: Iterable<T>): Set<T> = iterable.toSet()
+
+/**
+ * Preserves iteration order.
+ */
+fun <T> arrayToSet(array: Array<T>): Set<T> = array.toSet()
 
 fun <T> iteratorToStream(iterator: Iterator<T>): Stream<T> = iterator.asSequence().asStream()
 
@@ -40,7 +52,25 @@ fun <K, V> merge(vararg maps: Map<K, V>): Map<K, V> {
     return map
 }
 
+fun <T> isEmpty(iterable: Iterable<T>): Boolean = iterable.count() == 0
+
 fun <T> first(iterable: Iterable<T>): T? = iterable.iterator().nonEmpty?.next()
+
+fun <T> size(iterable: Iterable<T>): Int = iterable.count()
+
+fun <T> append(list: List<T>, elem: T): List<T> = list.plus(elem)
+
+fun <T> append(list: List<T>, elements: Array<T>): List<T> = list.plus(elements)
+
+fun <K, V> orderedMap(vararg entries: com.hotels.styx.common.Pair<K, V>): Map<K, V> {
+    val map = LinkedHashMap<K, V>()
+
+    entries.forEach {
+        map[it.key()] = it.value()
+    }
+
+    return map
+}
 
 // Private functions can use whatever Kotlin features as Java code will not see them.
 

--- a/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
+++ b/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
@@ -1,0 +1,47 @@
+/*
+  Copyright (C) 2013-2021 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.javaconvenience
+
+import java.util.stream.Stream
+import kotlin.streams.asStream
+
+/*
+ * Note: although written in Kotlin, these convenience methods are intended to be used by Java code.
+ * As such, certain language features that make Kotlin development easier will have no benefit in Java (or possibly make things more complicated),
+ * for example, extension methods, this-receivers.
+ */
+
+fun <T> iteratorToList(iterator: Iterator<T>): List<T> = Iterable {
+    iterator
+}.toList()
+
+fun <T> iterableToList(iterable: Iterable<T>): List<T> = iterable.toList()
+
+fun <T> iteratorToStream(iterator: Iterator<T>): Stream<T> = iterator.asSequence().asStream()
+
+fun <K, V> merge(vararg maps: Map<K, V>): Map<K, V> {
+    val map = HashMap<K, V>()
+    maps.forEach {
+        map.putAll(it)
+    }
+    return map
+}
+
+fun <T> first(iterable: Iterable<T>): T? = iterable.iterator().nonEmpty?.next()
+
+// Private functions can use whatever Kotlin features as Java code will not see them.
+
+private val <T> Iterator<T>.nonEmpty: Iterator<T>? get() = takeIf { it.hasNext() }

--- a/components/common/src/test/java/com/hotels/styx/common/MapStreamTest.java
+++ b/components/common/src/test/java/com/hotels/styx/common/MapStreamTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.common;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import java.util.AbstractMap.SimpleEntry;
@@ -29,7 +28,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 
 public class MapStreamTest {
-    private final Map<String, String> map = ImmutableMap.of(
+    private final Map<String, String> map = Map.of(
             "firstName", "John",
             "lastName", "Smith",
             "dateOfBirth", "1970-01-01"

--- a/components/common/src/test/java/com/hotels/styx/config/schema/SchemaTest.java
+++ b/components/common/src/test/java/com/hotels/styx/config/schema/SchemaTest.java
@@ -19,11 +19,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -61,9 +60,9 @@ public class SchemaTest {
                 + "  myOkValue: 5 \n"
                 + "  myNokValue: true \n");
 
-        integer().validate(ImmutableList.of("myOkValue"), root, root.get("myOkValue"), NO_EXTENSIONS);
+        integer().validate(List.of("myOkValue"), root, root.get("myOkValue"), NO_EXTENSIONS);
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> integer().validate(ImmutableList.of("myNokValue"), root, root.get("myNokValue"), NO_EXTENSIONS));
+                () -> integer().validate(List.of("myNokValue"), root, root.get("myNokValue"), NO_EXTENSIONS));
         assertEquals("Unexpected field type. Field 'myNokValue' should be INTEGER, but it is BOOLEAN", e.getMessage());
     }
 
@@ -73,9 +72,9 @@ public class SchemaTest {
                 + "  myOkValue: abc \n"
                 + "  myNokValue: 34 \n");
 
-        string().validate(ImmutableList.of("myOkValue"), root, root.get("myOkValue"), NO_EXTENSIONS);
+        string().validate(List.of("myOkValue"), root, root.get("myOkValue"), NO_EXTENSIONS);
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> string().validate(ImmutableList.of("myNokValue"), root, root.get("myNokValue"), NO_EXTENSIONS));
+                () -> string().validate(List.of("myNokValue"), root, root.get("myNokValue"), NO_EXTENSIONS));
         assertEquals("Unexpected field type. Field 'myNokValue' should be STRING, but it is NUMBER", e.getMessage());
     }
 
@@ -84,7 +83,7 @@ public class SchemaTest {
         JsonNode root = YAML_MAPPER.readTree(""
                 + "  myInt: '5' \n");
 
-        integer().validate(ImmutableList.of("myInt"), root, root.get("myInt"), NO_EXTENSIONS);
+        integer().validate(List.of("myInt"), root, root.get("myInt"), NO_EXTENSIONS);
     }
 
 
@@ -95,10 +94,10 @@ public class SchemaTest {
                 + "  myOkValue2: false \n"
                 + "  myNokValue: x \n");
 
-        bool().validate(ImmutableList.of("myOkValue1"), root, root.get("myOkValue1"), NO_EXTENSIONS);
-        bool().validate(ImmutableList.of("myOkValue2"), root, root.get("myOkValue2"), NO_EXTENSIONS);
+        bool().validate(List.of("myOkValue1"), root, root.get("myOkValue1"), NO_EXTENSIONS);
+        bool().validate(List.of("myOkValue2"), root, root.get("myOkValue2"), NO_EXTENSIONS);
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> bool().validate(ImmutableList.of("myNokValue"), root, root.get("myNokValue"), NO_EXTENSIONS));
+                () -> bool().validate(List.of("myNokValue"), root, root.get("myNokValue"), NO_EXTENSIONS));
         assertEquals("Unexpected field type. Field 'myNokValue' should be BOOLEAN, but it is STRING", e.getMessage());
     }
 
@@ -114,12 +113,12 @@ public class SchemaTest {
                 + "  myBool_06: 'FALSE' \n"
         );
 
-        bool().validate(ImmutableList.of(), rootObject, rootObject.get("myBool_01"), NO_EXTENSIONS);
-        bool().validate(ImmutableList.of(), rootObject, rootObject.get("myBool_02"), NO_EXTENSIONS);
-        bool().validate(ImmutableList.of(), rootObject, rootObject.get("myBool_03"), NO_EXTENSIONS);
-        bool().validate(ImmutableList.of(), rootObject, rootObject.get("myBool_04"), NO_EXTENSIONS);
-        bool().validate(ImmutableList.of(), rootObject, rootObject.get("myBool_05"), NO_EXTENSIONS);
-        bool().validate(ImmutableList.of(), rootObject, rootObject.get("myBool_06"), NO_EXTENSIONS);
+        bool().validate(List.of(), rootObject, rootObject.get("myBool_01"), NO_EXTENSIONS);
+        bool().validate(List.of(), rootObject, rootObject.get("myBool_02"), NO_EXTENSIONS);
+        bool().validate(List.of(), rootObject, rootObject.get("myBool_03"), NO_EXTENSIONS);
+        bool().validate(List.of(), rootObject, rootObject.get("myBool_04"), NO_EXTENSIONS);
+        bool().validate(List.of(), rootObject, rootObject.get("myBool_05"), NO_EXTENSIONS);
+        bool().validate(List.of(), rootObject, rootObject.get("myBool_06"), NO_EXTENSIONS);
     }
 
 
@@ -137,7 +136,7 @@ public class SchemaTest {
                                 field("surname", string()),
                                 field("age", integer())
                         ))
-                ).validate(ImmutableList.of(), rootObject, rootObject, x -> null));
+                ).validate(List.of(), rootObject, rootObject, x -> null));
         assertEquals("Missing a mandatory field 'root.surname'", e.getMessage());
     }
 
@@ -154,7 +153,7 @@ public class SchemaTest {
                         optional("favouriteFood", string()),
                         field("age", integer())
                 ))
-        ).validate(ImmutableList.of("root"), rootObject, rootObject, NO_EXTENSIONS);
+        ).validate(List.of("root"), rootObject, rootObject, NO_EXTENSIONS);
     }
 
 
@@ -173,7 +172,7 @@ public class SchemaTest {
                                 optional("favouriteFood", string()),
                                 field("age", integer())
                         ))
-                ).validate(ImmutableList.of(), rootObject, rootObject, NO_EXTENSIONS));
+                ).validate(List.of(), rootObject, rootObject, NO_EXTENSIONS));
         assertEquals("Unexpected field type. Field 'root.favouriteFood' should be STRING, but it is NUMBER", e.getMessage());
     }
 
@@ -193,7 +192,7 @@ public class SchemaTest {
                                 field("surname", string()),
                                 field("age", integer())
                         ))
-                ).validate(ImmutableList.of(), rootObject, rootObject, NO_EXTENSIONS));
+                ).validate(List.of(), rootObject, rootObject, NO_EXTENSIONS));
         assertEquals("Unexpected field: 'root.xyxz'", e.getMessage());
     }
 
@@ -209,7 +208,7 @@ public class SchemaTest {
                         field("root", object(
                                 field("myInt", integer())
                         ))
-                ).validate(ImmutableList.of(), rootObject, rootObject, NO_EXTENSIONS));
+                ).validate(List.of(), rootObject, rootObject, NO_EXTENSIONS));
         assertEquals("Unexpected field type. Field 'root.myInt' should be INTEGER, but it is STRING", e.getMessage());
     }
 
@@ -225,7 +224,7 @@ public class SchemaTest {
                         field("root", object(
                                 field("myString", string())
                         ))
-                ).validate(ImmutableList.of(), rootObject, rootObject, NO_EXTENSIONS));
+                ).validate(List.of(), rootObject, rootObject, NO_EXTENSIONS));
         assertEquals("Unexpected field type. Field 'root.myString' should be STRING, but it is NUMBER", e.getMessage());
     }
 
@@ -241,7 +240,7 @@ public class SchemaTest {
                         field("root", object(
                                 field("myBool", bool())
                         ))
-                ).validate(ImmutableList.of(), rootObject, rootObject, NO_EXTENSIONS));
+                ).validate(List.of(), rootObject, rootObject, NO_EXTENSIONS));
         assertEquals("Unexpected field type. Field 'root.myBool' should be BOOLEAN, but it is NUMBER", e.getMessage());
     }
 
@@ -301,7 +300,7 @@ public class SchemaTest {
                 () -> object(
                         field("parent", object(
                                 field("child", string())))
-                ).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
+                ).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'parent' should be OBJECT\\(parent\\), but it is STRING"));
     }
 
@@ -345,11 +344,11 @@ public class SchemaTest {
                         atLeastOne("http", "https")
                 )));
 
-        objectType.validate(ImmutableList.of(), first, first, NO_EXTENSIONS);
-        objectType.validate(ImmutableList.of(), second, second, NO_EXTENSIONS);
-        objectType.validate(ImmutableList.of(), both, both, NO_EXTENSIONS);
+        objectType.validate(List.of(), first, first, NO_EXTENSIONS);
+        objectType.validate(List.of(), second, second, NO_EXTENSIONS);
+        objectType.validate(List.of(), both, both, NO_EXTENSIONS);
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> objectType.validate(ImmutableList.of(), neither, neither, NO_EXTENSIONS));
+                () -> objectType.validate(List.of(), neither, neither, NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Schema constraint failed. At least one of \\('http', 'https'\\) must be present."));
     }
 
@@ -362,7 +361,7 @@ public class SchemaTest {
         );
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> list(string()).validate(ImmutableList.of("myList"), rootObject, rootObject.get("myList"), NO_EXTENSIONS));
+                () -> list(string()).validate(List.of("myList"), rootObject, rootObject.get("myList"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'myList\\[1\\]' should be STRING, but it is NUMBER"));
     }
 
@@ -375,7 +374,7 @@ public class SchemaTest {
         );
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> list(integer()).validate(ImmutableList.of("myList"), rootObject, rootObject.get("myList"), NO_EXTENSIONS));
+                () -> list(integer()).validate(List.of("myList"), rootObject, rootObject.get("myList"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'myList\\[0\\]' should be INTEGER, but it is STRING"));
     }
 
@@ -393,7 +392,7 @@ public class SchemaTest {
                 () -> list(object(
                         field("x", integer()),
                         field("y", integer())
-                )).validate(ImmutableList.of("myList"), rootObject, rootObject.get("myList"), NO_EXTENSIONS));
+                )).validate(List.of("myList"), rootObject, rootObject.get("myList"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'myList\\[1\\].x' should be INTEGER, but it is STRING"));
     }
 
@@ -412,7 +411,7 @@ public class SchemaTest {
         );
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> list(subObject).validate(ImmutableList.of("myList"), rootObject, rootObject.get("myList"), NO_EXTENSIONS));
+                () -> list(subObject).validate(List.of("myList"), rootObject, rootObject.get("myList"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'myList\\[1\\]' should be OBJECT\\(x, y\\), but it is STRING"));
     }
 
@@ -423,7 +422,7 @@ public class SchemaTest {
         );
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> list(integer()).validate(ImmutableList.of("myList"), root, root.get("myList"), NO_EXTENSIONS));
+                () -> list(integer()).validate(List.of("myList"), root, root.get("myList"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'myList' should be LIST\\(INTEGER\\), but it is STRING"));
     }
 
@@ -436,7 +435,7 @@ public class SchemaTest {
         );
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> list(integer()).validate(ImmutableList.of("myList"), root, root.get("myList"), NO_EXTENSIONS));
+                () -> list(integer()).validate(List.of("myList"), root, root.get("myList"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'myList' should be LIST\\(INTEGER\\), but it is OBJECT"));
     }
 
@@ -450,7 +449,7 @@ public class SchemaTest {
 
         Exception e = assertThrows(SchemaValidationException.class,
                 () -> list(object(field("a", integer()), field("b", integer())))
-                        .validate(ImmutableList.of("myList"), root, root.get("myList"), NO_EXTENSIONS));
+                        .validate(List.of("myList"), root, root.get("myList"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'myList' should be LIST\\(OBJECT\\(a, b\\)\\), but it is OBJECT"));
     }
 
@@ -458,7 +457,7 @@ public class SchemaTest {
     @Test
     public void routingObject_routingObjectDefinition() throws Exception {
 
-        Map<String, Schema.FieldType> extensions = ImmutableMap.of(
+        Map<String, Schema.FieldType> extensions = Map.of(
                 "ProxyTo", object(
                         field("id", string()),
                         field("destination", string())
@@ -500,7 +499,7 @@ public class SchemaTest {
                 () -> object(
                         field("config", union("type")),
                         field("type", string())
-                ).validate(ImmutableList.of("httpPipeline"), root, root.get("httpPipeline"), NO_EXTENSIONS));
+                ).validate(List.of("httpPipeline"), root, root.get("httpPipeline"), NO_EXTENSIONS));
         assertEquals("Union discriminator 'httpPipeline.config.type': Unexpected field type. Field 'httpPipeline.config.type' should be STRING, but it is NUMBER", e.getMessage());
     }
 
@@ -519,7 +518,7 @@ public class SchemaTest {
                 () -> object(
                         field("type", string()),
                         field("config", union("type"))
-                ).validate(ImmutableList.of("httpPipeline"), root, root.get("httpPipeline"), NO_EXTENSIONS));
+                ).validate(List.of("httpPipeline"), root, root.get("httpPipeline"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unknown union discriminator type 'Foo' for union 'httpPipeline.config'. Union type is UNION\\(type\\)"));
     }
 
@@ -527,7 +526,7 @@ public class SchemaTest {
     @Test
     public void union_validatesDiscriminatedUnions() throws Exception {
 
-        Map<String, Schema.FieldType> extensions = ImmutableMap.of(
+        Map<String, Schema.FieldType> extensions = Map.of(
                 "ProxyTo", object(
                         field("id", string()),
                         field("destination", string())
@@ -556,8 +555,8 @@ public class SchemaTest {
                 field("config", union("type"))
         );
 
-        unionSchema.validate(ImmutableList.of(), root, root.get("httpPipeline1"), extensions::get);
-        unionSchema.validate(ImmutableList.of(), root, root.get("httpPipeline2"), extensions::get);
+        unionSchema.validate(List.of(), root, root.get("httpPipeline1"), extensions::get);
+        unionSchema.validate(List.of(), root, root.get("httpPipeline2"), extensions::get);
     }
 
 
@@ -568,7 +567,7 @@ public class SchemaTest {
         );
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> map(string()).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
+                () -> map(string()).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'parent' should be MAP\\(STRING\\), but it is STRING"));
     }
 
@@ -587,7 +586,7 @@ public class SchemaTest {
         map(object(
                 field("x", integer()),
                 field("y", integer())
-        )).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
+        )).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
 
     }
 
@@ -603,7 +602,7 @@ public class SchemaTest {
                 () -> map(object(
                         field("x", integer()),
                         field("y", integer())
-                )).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
+                )).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'parent\\[key.\\]' should be OBJECT\\(x, y\\), but it is NUMBER"));
     }
 
@@ -615,7 +614,7 @@ public class SchemaTest {
                         + "  key2: 24\n"
         );
 
-        map(integer()).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
+        map(integer()).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
     }
 
     @Test
@@ -627,7 +626,7 @@ public class SchemaTest {
         );
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> map(integer()).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
+                () -> map(integer()).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'parent\\[key1\\]' should be INTEGER, but it is STRING"));
     }
 
@@ -639,7 +638,7 @@ public class SchemaTest {
                         + "  key2: 'two'\n"
         );
 
-        map(string()).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
+        map(string()).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
     }
 
     @Test
@@ -651,7 +650,7 @@ public class SchemaTest {
         );
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> map(string()).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
+                () -> map(string()).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'parent\\[key1\\]' should be STRING, but it is NUMBER"));
     }
 
@@ -663,7 +662,7 @@ public class SchemaTest {
                         + "  nok: False\n"
         );
 
-        map(bool()).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
+        map(bool()).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
     }
 
     @Test
@@ -675,7 +674,7 @@ public class SchemaTest {
         );
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> map(bool()).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
+                () -> map(bool()).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'parent\\[ok\\]' should be BOOLEAN, but it is STRING"));
     }
 
@@ -691,7 +690,7 @@ public class SchemaTest {
                         + "    - 4\n"
         );
 
-        map(list(integer())).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
+        map(list(integer())).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
     }
 
     @Test
@@ -707,7 +706,7 @@ public class SchemaTest {
         );
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> map(list(integer())).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
+                () -> map(list(integer())).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'parent\\[key1\\]' should be LIST\\(INTEGER\\), but it is OBJECT"));
     }
 
@@ -728,7 +727,7 @@ public class SchemaTest {
                         field("y", integer()
                         )
                 )
-        )).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
+        )).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS);
     }
 
     @Test
@@ -748,7 +747,7 @@ public class SchemaTest {
                                 field("y", integer()
                                 )
                         )
-                )).validate(ImmutableList.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
+                )).validate(List.of("parent"), root, root.get("parent"), NO_EXTENSIONS));
         assertThat(e.getMessage(), matchesPattern("Unexpected field type. Field 'parent\\[mapKey\\]\\[0\\]' should be OBJECT\\(x, y\\), but it is STRING"));
     }
 
@@ -784,11 +783,11 @@ public class SchemaTest {
 
         Schema.FieldType myOr = or(list(string()), string());
 
-        myOr.validate(ImmutableList.of("pipeline"), root, root.get("pipeline"), NO_EXTENSIONS);
-        myOr.validate(ImmutableList.of("pipeline2"), root, root.get("pipeline2"), NO_EXTENSIONS);
+        myOr.validate(List.of("pipeline"), root, root.get("pipeline"), NO_EXTENSIONS);
+        myOr.validate(List.of("pipeline2"), root, root.get("pipeline2"), NO_EXTENSIONS);
 
         Exception e = assertThrows(SchemaValidationException.class,
-                () -> myOr.validate(ImmutableList.of("pipeline3"), root, root.get("pipeline3"), NO_EXTENSIONS));
+                () -> myOr.validate(List.of("pipeline3"), root, root.get("pipeline3"), NO_EXTENSIONS));
 
         assertEquals("Unexpected field type. Field 'pipeline3' should be OR(LIST(STRING), STRING), but it is NUMBER", e.getMessage());
     }

--- a/components/proxy/src/main/java/com/hotels/styx/StyxPipelineFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxPipelineFactory.java
@@ -16,7 +16,6 @@
 package com.hotels.styx;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.extension.service.BackendService;
 import com.hotels.styx.api.extension.service.spi.Registry;
@@ -75,7 +74,7 @@ public class StyxPipelineFactory {
         Optional<JsonNode> rootHandlerNode = environment.configuration().get("httpPipeline", JsonNode.class);
 
         if (rootHandlerNode.isPresent()) {
-            return Builtins.build(ImmutableList.of("httpPipeline"), routingObjectFactoryContext, toRoutingConfigNode(rootHandlerNode.get()));
+            return Builtins.build(List.of("httpPipeline"), routingObjectFactoryContext, toRoutingConfigNode(rootHandlerNode.get()));
         }
 
         Registry<BackendService> registry = (Registry<BackendService>) services.get("backendServiceRegistry");

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.admin;
 
 import com.codahale.metrics.json.MetricsModule;
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.Environment;
 import com.hotels.styx.InetServer;
 import com.hotels.styx.NettyExecutor;
@@ -82,6 +81,7 @@ import static com.hotels.styx.metrics.MetricsExtensionsKt.findRegistry;
 import static com.hotels.styx.routing.config.ConfigVersionResolver.Version.ROUTING_CONFIG_V1;
 import static com.hotels.styx.routing.config.ConfigVersionResolver.configVersion;
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -222,27 +222,27 @@ public class AdminServerBuilder {
     }
 
     private static Iterable<IndexHandler.Link> indexLinkPaths(StyxConfig styxConfig) {
-        ImmutableList.Builder<IndexHandler.Link> builder = ImmutableList.builder();
-        builder.add(link("version.txt", "/version.txt"));
-        builder.add(link("uptime", "/admin/uptime"));
-        builder.add(link("Ping", "/admin/ping"));
-        builder.add(link("Threads", "/admin/threads"));
-        builder.add(link("Current Requests", "/admin/current_requests?withStackTrace=true"));
-        builder.add(link("Metrics", "/admin/metrics?pretty"));
-        builder.add(link("Configuration", "/admin/configuration?pretty"));
-        builder.add(link("Log Configuration", "/admin/configuration/logging"));
-        builder.add(link("Startup Configuration", "/admin/configuration/startup"));
-        builder.add(link("JVM", "/admin/jvm?pretty"));
-        builder.add(link("Plugins", "/admin/plugins"));
-        builder.add(link("Providers", "/admin/providers"));
-        builder.add(link("Prometheus", "/metrics"));
+        List<IndexHandler.Link> builder = new ArrayList<>(asList(
+                link("version.txt", "/version.txt"),
+                link("uptime", "/admin/uptime"),
+                link("Ping", "/admin/ping"),
+                link("Threads", "/admin/threads"),
+                link("Current Requests", "/admin/current_requests?withStackTrace=true"),
+                link("Metrics", "/admin/metrics?pretty"),
+                link("Configuration", "/admin/configuration?pretty"),
+                link("Log Configuration", "/admin/configuration/logging"),
+                link("Startup Configuration", "/admin/configuration/startup"),
+                link("JVM", "/admin/jvm?pretty"),
+                link("Plugins", "/admin/plugins"),
+                link("Providers", "/admin/providers"),
+                link("Prometheus", "/metrics")));
 
         if (configVersion(styxConfig) == ROUTING_CONFIG_V1) {
-            builder.add(link("Dashboard", "/admin/dashboard/index.html"))
-                    .add(link("Origins Status", "/admin/origins/status?pretty"))
-                    .add(link("Origins Configuration", "/admin/configuration/origins?pretty"));
+            builder.add(link("Dashboard", "/admin/dashboard/index.html"));
+            builder.add(link("Origins Status", "/admin/origins/status?pretty"));
+            builder.add(link("Origins Configuration", "/admin/configuration/origins?pretty"));
         }
-        return builder.build()
+        return builder
                 .stream()
                 .sorted()
                 .collect(toList());

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/RoutingObjectHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/RoutingObjectHandler.java
@@ -21,8 +21,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
@@ -38,6 +36,7 @@ import com.hotels.styx.routing.db.StyxObjectStore;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.AUTO_CLOSE_SOURCE;
@@ -93,9 +92,9 @@ public class RoutingObjectHandler implements WebServiceHandler {
 
                     try {
                         StyxObjectDefinition payload = YAML_MAPPER.readValue(body, StyxObjectDefinition.class);
-                        RoutingMetadataDecorator decorator = new RoutingMetadataDecorator(Builtins.build(ImmutableList.of(name), routingObjectFactoryContext, payload));
+                        RoutingMetadataDecorator decorator = new RoutingMetadataDecorator(Builtins.build(List.of(name), routingObjectFactoryContext, payload));
 
-                        routeDatabase.insert(name, new RoutingObjectRecord(payload.type(), ImmutableSet.copyOf(payload.tags()), payload.config(), decorator))
+                        routeDatabase.insert(name, new RoutingObjectRecord(payload.type(), Set.copyOf(payload.tags()), payload.config(), decorator))
                                 .ifPresent(previous -> previous.getRoutingObject().stop());
 
                         return Eventual.of(response(CREATED).build());

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ServiceProviderHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ServiceProviderHandler.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.collect.ImmutableList;
+import com.hotels.styx.StyxObjectRecord;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
@@ -30,7 +30,6 @@ import com.hotels.styx.api.WebServiceHandler;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
 import com.hotels.styx.routing.db.StyxObjectStore;
-import com.hotels.styx.StyxObjectRecord;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -110,7 +109,7 @@ public class ServiceProviderHandler implements WebServiceHandler {
     }
 
     private static String serialise(String name, StyxObjectRecord<StyxService> record) {
-        List<String> tags = ImmutableList.copyOf(record.getTags());
+        List<String> tags = List.copyOf(record.getTags());
         StyxObjectDefinition objectDef =
                 new StyxObjectDefinition(name, record.getType(), tags, record.getConfig());
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/StartupConfigHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/StartupConfigHandler.java
@@ -15,9 +15,10 @@
  */
 package com.hotels.styx.admin.handlers;
 
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.StartupConfig;
 import com.hotels.styx.common.http.handler.StaticBodyHttpHandler;
+
+import java.util.stream.Stream;
 
 import static com.google.common.net.MediaType.HTML_UTF_8;
 import static java.util.stream.Collectors.joining;
@@ -36,12 +37,10 @@ public class StartupConfigHandler extends StaticBodyHttpHandler {
     }
 
     private static String render(StartupConfig startupConfig) {
-        return ImmutableMap.of(
-                "Styx Home", startupConfig.styxHome(),
-                "Config File Location", startupConfig.configFileLocation(),
-                "Log Config Location", startupConfig.logConfigLocation())
-                .entrySet().stream()
-                .map(entry -> entry.getKey() + "='" + entry.getValue() + "'")
-                .collect(joining("<br />", "<html><body>", "</body></html>"));
+        return Stream.of(
+                "Styx Home='" + startupConfig.styxHome() + "'",
+                "Config File Location='" + startupConfig.configFileLocation() + "'",
+                "Log Config Location='" + startupConfig.logConfigLocation() + "'"
+        ).collect(joining("<br />", "<html><body>", "</body></html>"));
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/UrlPatternRouter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/UrlPatternRouter.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.admin.handlers;
 
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpMethod;
@@ -50,7 +49,7 @@ public class UrlPatternRouter implements WebServiceHandler {
     private final List<RouteDescriptor> alternatives;
 
     private UrlPatternRouter(List<RouteDescriptor> alternatives) {
-        this.alternatives = ImmutableList.copyOf(alternatives);
+        this.alternatives = List.copyOf(alternatives);
     }
 
     public static Map<String, String> placeholders(HttpInterceptor.Context context) {

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/VersionTextHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/VersionTextHandler.java
@@ -25,9 +25,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Optional;
 
-import static com.google.common.collect.Iterables.isEmpty;
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.hotels.styx.common.Preconditions.checkArgument;
+import static com.hotels.styx.javaconvenience.UtilKt.isEmpty;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**

--- a/components/proxy/src/main/java/com/hotels/styx/applications/BackendServices.java
+++ b/components/proxy/src/main/java/com/hotels/styx/applications/BackendServices.java
@@ -17,7 +17,6 @@ package com.hotels.styx.applications;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableSet;
 import com.hotels.styx.api.Id;
 import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.extension.service.BackendService;
@@ -32,6 +31,8 @@ import static com.google.common.collect.Iterables.getFirst;
 import static com.hotels.styx.api.extension.Origin.newOriginBuilder;
 import static com.hotels.styx.api.extension.service.BackendService.newBackendServiceBuilder;
 import static com.hotels.styx.common.Preconditions.checkArgument;
+import static com.hotels.styx.javaconvenience.UtilKt.arrayToSet;
+import static com.hotels.styx.javaconvenience.UtilKt.iterableToSet;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -54,8 +55,8 @@ public final class BackendServices implements Iterable<BackendService> {
         checkArgument(noDuplicateIds(backendServices), "Duplicate ids in " + backendServices);
 
         if (setDerivedAttributes) {
-            // note: ImmutableSet preserves order
-            this.backendServices = ImmutableSet.copyOf(backendServices.stream().map(BackendServices::setDerivedAttributes).collect(toList()));
+            // note: preserves order
+            this.backendServices = iterableToSet(backendServices.stream().map(BackendServices::setDerivedAttributes).collect(toList()));
         } else {
             this.backendServices = backendServices;
         }
@@ -74,7 +75,7 @@ public final class BackendServices implements Iterable<BackendService> {
      * @return a new Applications
      */
     public static BackendServices newBackendServices(Iterable<BackendService> applications) {
-        return new BackendServices(ImmutableSet.copyOf(applications), true);
+        return new BackendServices(iterableToSet(applications), true);
     }
 
     /**
@@ -84,7 +85,7 @@ public final class BackendServices implements Iterable<BackendService> {
      * @return a new Applications
      */
     public static BackendServices newBackendServices(BackendService... backendServices) {
-        return new BackendServices(ImmutableSet.copyOf(backendServices), true);
+        return new BackendServices(arrayToSet(backendServices), true);
     }
 
     private static BackendService setDerivedAttributes(BackendService application) {
@@ -94,7 +95,7 @@ public final class BackendServices implements Iterable<BackendService> {
     }
 
     private static Set<Origin> originsWithDerivedApplicationIds(BackendService backendService) {
-        return ImmutableSet.copyOf(originsWithApplicationId(backendService));
+        return iterableToSet(originsWithApplicationId(backendService));
     }
 
     private static Iterable<Origin> originsWithApplicationId(BackendService backendService) {

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/MemoryBackedRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/MemoryBackedRegistry.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.infrastructure;
 
-import com.google.common.collect.ImmutableSet;
 import com.hotels.styx.api.Environment;
 import com.hotels.styx.api.Id;
 import com.hotels.styx.api.Identifiable;
@@ -25,6 +24,7 @@ import com.hotels.styx.api.extension.service.spi.Registry;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.reloaded;
@@ -84,7 +84,7 @@ public class MemoryBackedRegistry<T extends Identifiable> extends AbstractRegist
 
     @Override
     public CompletableFuture<ReloadResult> reload() {
-        set(ImmutableSet.copyOf(resources.values()));
+        set(Set.copyOf(resources.values()));
         return completedFuture(reloaded("changed"));
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/yaml/PlaceholderResolver.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/yaml/PlaceholderResolver.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.infrastructure.configuration.UnresolvedPlaceholder;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonTreeTraversal.JsonTreeVisitor;
 import org.slf4j.Logger;
@@ -58,7 +57,7 @@ public class PlaceholderResolver {
 
     public PlaceholderResolver(ObjectNode rootNode, Map<String, String> externalProperties) {
         this.rootNode = requireNonNull(rootNode);
-        this.externalProperties = ImmutableMap.copyOf(externalProperties);
+        this.externalProperties = Map.copyOf(externalProperties);
     }
 
     /**

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/logging/ExceptionConverter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/logging/ExceptionConverter.java
@@ -30,9 +30,9 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static ch.qos.logback.core.CoreConstants.LINE_SEPARATOR;
-import static com.google.common.base.Charsets.UTF_8;
 import static com.hotels.styx.common.Strings.isNotEmpty;
 import static java.lang.Integer.toHexString;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/InterceptorPipelineBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/InterceptorPipelineBuilder.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.proxy;
 
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.Environment;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.proxy.plugin.InstrumentedPlugin;
@@ -46,7 +45,7 @@ public class InterceptorPipelineBuilder {
     }
 
     public RoutingObject build() {
-        List<HttpInterceptor> interceptors = ImmutableList.copyOf(instrument(plugins, environment));
+        List<HttpInterceptor> interceptors = List.copyOf(instrument(plugins, environment));
         return new HttpInterceptorPipeline(interceptors, handler, trackRequests);
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/PluginsMetadata.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/plugin/PluginsMetadata.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.proxy.plugin;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.common.Pair;
 import com.hotels.styx.common.Strings;
 import com.hotels.styx.spi.config.SpiExtension;
@@ -48,7 +47,7 @@ public class PluginsMetadata implements Iterable<SpiExtension> {
                 .filter(Strings::isNotEmpty)
                 .collect(toList());
 
-        this.allPluginNames = ImmutableList.copyOf(plugins.keySet());
+        this.allPluginNames = List.copyOf(plugins.keySet());
         this.plugins = plugins;
 
         plugins.forEach((name, metadata) -> {

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/Builtins.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/Builtins.java
@@ -15,11 +15,10 @@
  */
 package com.hotels.styx.routing.config;
 
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.ExecutorFactory;
 import com.hotels.styx.InetServer;
-import com.hotels.styx.StyxObjectRecord;
 import com.hotels.styx.NettyExecutor;
+import com.hotels.styx.StyxObjectRecord;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.extension.service.spi.StyxService;
@@ -71,37 +70,37 @@ public final class Builtins {
 
     public static final String REWRITE = "Rewrite";
 
-    public static final ImmutableMap<String, Schema.FieldType> BUILTIN_HANDLER_SCHEMAS;
-    public static final ImmutableMap<String, RoutingObjectFactory> BUILTIN_HANDLER_FACTORIES;
+    public static final Map<String, Schema.FieldType> BUILTIN_HANDLER_SCHEMAS;
+    public static final Map<String, RoutingObjectFactory> BUILTIN_HANDLER_FACTORIES;
 
-    public static final ImmutableMap<String, HttpInterceptorFactory> INTERCEPTOR_FACTORIES =
-            ImmutableMap.of(REWRITE, new RewriteInterceptor.Factory());
+    public static final Map<String, HttpInterceptorFactory> INTERCEPTOR_FACTORIES =
+            Map.of(REWRITE, new RewriteInterceptor.Factory());
 
-    public static final ImmutableMap<String, Schema.FieldType> INTERCEPTOR_SCHEMAS =
-            ImmutableMap.of(REWRITE, RewriteInterceptor.SCHEMA);
+    public static final Map<String, Schema.FieldType> INTERCEPTOR_SCHEMAS =
+            Map.of(REWRITE, RewriteInterceptor.SCHEMA);
 
-    public static final ImmutableMap<String, ServiceProviderFactory> BUILTIN_SERVICE_PROVIDER_FACTORIES =
-            ImmutableMap.of(HEALTH_CHECK_MONITOR, new HealthCheckMonitoringServiceFactory(),
+    public static final Map<String, ServiceProviderFactory> BUILTIN_SERVICE_PROVIDER_FACTORIES =
+            Map.of(HEALTH_CHECK_MONITOR, new HealthCheckMonitoringServiceFactory(),
                     YAML_FILE_CONFIGURATION_SERVICE, new YamlFileConfigurationServiceFactory()
             );
 
-    public static final ImmutableMap<String, Schema.FieldType> BUILTIN_SERVICE_PROVIDER_SCHEMAS =
-            ImmutableMap.of(HEALTH_CHECK_MONITOR, HealthCheckMonitoringService.SCHEMA,
+    public static final Map<String, Schema.FieldType> BUILTIN_SERVICE_PROVIDER_SCHEMAS =
+            Map.of(HEALTH_CHECK_MONITOR, HealthCheckMonitoringService.SCHEMA,
                     YAML_FILE_CONFIGURATION_SERVICE, YamlFileConfigurationService.SCHEMA);
 
-    public static final ImmutableMap<String, StyxServerFactory> BUILTIN_SERVER_FACTORIES = ImmutableMap.of(
+    public static final Map<String, StyxServerFactory> BUILTIN_SERVER_FACTORIES = Map.of(
             "HttpServer", new StyxHttpServerFactory()
     );
 
-    public static final ImmutableMap<String, Schema.FieldType> BUILTIN_SERVER_SCHEMAS = ImmutableMap.of(
+    public static final Map<String, Schema.FieldType> BUILTIN_SERVER_SCHEMAS = Map.of(
             "HttpServer", StyxHttpServer.SCHEMA
     );
 
-    public static final ImmutableMap<String, ExecutorFactory> BUILTIN_EXECUTOR_FACTORIES = ImmutableMap.of(
+    public static final Map<String, ExecutorFactory> BUILTIN_EXECUTOR_FACTORIES = Map.of(
             "NettyExecutor", new NettyExecutorFactory()
     );
 
-    public static final ImmutableMap<String, Schema.FieldType> BUILTIN_EXECUTOR_SCHEMAS = ImmutableMap.of(
+    public static final Map<String, Schema.FieldType> BUILTIN_EXECUTOR_SCHEMAS = Map.of(
             "NettyExecutor", NettyExecutorFactory.SCHEMA
     );
 
@@ -113,25 +112,23 @@ public final class Builtins {
 
 
     static {
-        BUILTIN_HANDLER_FACTORIES = ImmutableMap.<String, RoutingObjectFactory>builder()
-                .put(STATIC_RESPONSE, new StaticResponseHandler.Factory())
-                .put(CONDITION_ROUTER, new ConditionRouter.Factory())
-                .put(INTERCEPTOR_PIPELINE, new HttpInterceptorPipeline.Factory())
-                .put(PROXY_TO_BACKEND, new ProxyToBackend.Factory())
-                .put(PATH_PREFIX_ROUTER, new PathPrefixRouter.Factory())
-                .put(HOST_PROXY, new HostProxy.Factory())
-                .put(LOAD_BALANCING_GROUP, new LoadBalancingGroup.Factory())
-                .build();
+        BUILTIN_HANDLER_FACTORIES = Map.of(
+                STATIC_RESPONSE, new StaticResponseHandler.Factory(),
+                CONDITION_ROUTER, new ConditionRouter.Factory(),
+                INTERCEPTOR_PIPELINE, new HttpInterceptorPipeline.Factory(),
+                PROXY_TO_BACKEND, new ProxyToBackend.Factory(),
+                PATH_PREFIX_ROUTER, new PathPrefixRouter.Factory(),
+                HOST_PROXY, new HostProxy.Factory(),
+                LOAD_BALANCING_GROUP, new LoadBalancingGroup.Factory());
 
-        BUILTIN_HANDLER_SCHEMAS = ImmutableMap.<String, Schema.FieldType>builder()
-                .put(STATIC_RESPONSE, StaticResponseHandler.SCHEMA)
-                .put(CONDITION_ROUTER, ConditionRouter.SCHEMA)
-                .put(INTERCEPTOR_PIPELINE, HttpInterceptorPipeline.SCHEMA)
-                .put(PROXY_TO_BACKEND, ProxyToBackend.SCHEMA)
-                .put(PATH_PREFIX_ROUTER, PathPrefixRouter.SCHEMA)
-                .put(HOST_PROXY, HostProxy.SCHEMA)
-                .put(LOAD_BALANCING_GROUP,  LoadBalancingGroup.Companion.getSCHEMA())
-                .build();
+        BUILTIN_HANDLER_SCHEMAS = Map.of(
+                STATIC_RESPONSE, StaticResponseHandler.SCHEMA,
+                CONDITION_ROUTER, ConditionRouter.SCHEMA,
+                INTERCEPTOR_PIPELINE, HttpInterceptorPipeline.SCHEMA,
+                PROXY_TO_BACKEND, ProxyToBackend.SCHEMA,
+                PATH_PREFIX_ROUTER, PathPrefixRouter.SCHEMA,
+                HOST_PROXY, HostProxy.SCHEMA,
+                LOAD_BALANCING_GROUP,  LoadBalancingGroup.Companion.getSCHEMA());
     }
 
     private Builtins() {

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingSupport.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/RoutingSupport.java
@@ -15,7 +15,7 @@
  */
 package com.hotels.styx.routing.config;
 
-import com.google.common.collect.ImmutableList;
+import com.hotels.styx.javaconvenience.UtilKt;
 
 import java.util.List;
 
@@ -30,12 +30,7 @@ public final class RoutingSupport {
     }
 
     public static <T> List<T> append(List<T> list, T elem) {
-        ImmutableList.Builder<T> builder = ImmutableList.builder();
-
-        builder.addAll(list);
-        builder.add(elem);
-
-        return builder.build();
+        return UtilKt.append(list, elem);
     }
 
     public static RuntimeException missingAttributeError(StyxObjectDefinition routingDef, String parent, String expected) {

--- a/components/proxy/src/main/java/com/hotels/styx/routing/config/StyxObjectDefinition.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/config/StyxObjectDefinition.java
@@ -18,7 +18,6 @@ package com.hotels.styx.routing.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 
 import java.util.List;
@@ -38,12 +37,12 @@ public class StyxObjectDefinition implements StyxObjectConfiguration {
     public StyxObjectDefinition(String name, String type, List<String> tags, JsonNode config) {
         this.name = requireNonNull(name);
         this.type = requireNonNull(type);
-        this.tags = ImmutableList.copyOf(tags);
+        this.tags = List.copyOf(tags);
         this.config = requireNonNull(config);
     }
 
     public StyxObjectDefinition(String name, String type, JsonNode config) {
-        this(name, type, ImmutableList.of(), config);
+        this(name, type, List.of(), config);
     }
 
     public String name() {
@@ -67,7 +66,7 @@ public class StyxObjectDefinition implements StyxObjectConfiguration {
     }
 
     static class Builder {
-        private List<String> tags = ImmutableList.of();
+        private List<String> tags = List.of();
         private String name = "";
 
         private JsonNode config;

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HttpInterceptorPipeline.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HttpInterceptorPipeline.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.routing.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
@@ -111,7 +110,7 @@ public class HttpInterceptorPipeline implements RoutingObject {
                 Map<String, HttpInterceptorFactory> interceptorFactories,
                 JsonNode pipeline) {
             if (pipeline == null || pipeline.isNull()) {
-                return ImmutableList.of();
+                return List.of();
             }
             List<StyxObjectConfiguration> interceptorConfigs = styxHttpPipeline(pipeline);
             ensureValidPluginReferences(parents, plugins, interceptorConfigs);

--- a/components/proxy/src/main/java/com/hotels/styx/routing/interceptors/RewriteInterceptor.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/interceptors/RewriteInterceptor.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.routing.interceptors;
 
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
@@ -27,6 +26,9 @@ import com.hotels.styx.config.schema.Schema;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 import com.hotels.styx.routing.config.HttpInterceptorFactory;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.hotels.styx.config.schema.SchemaDsl.field;
 import static com.hotels.styx.config.schema.SchemaDsl.list;
@@ -60,7 +62,7 @@ public class RewriteInterceptor implements HttpInterceptor {
     public static class Factory implements HttpInterceptorFactory {
         @Override
         public HttpInterceptor build(StyxObjectDefinition configBlock) {
-            ImmutableList.Builder<RewriteRule> rules = ImmutableList.builder();
+            List<RewriteRule> rules = new ArrayList<>();
             configBlock.config().iterator().forEachRemaining(
                     node -> {
                         RewriteConfig rewriteConfig = new JsonNodeConfig(node).as(RewriteConfig.class);
@@ -68,7 +70,7 @@ public class RewriteInterceptor implements HttpInterceptor {
                     }
             );
 
-            return new RewriteInterceptor(new RewriteRuleset(rules.build()));
+            return new RewriteInterceptor(new RewriteRuleset(List.copyOf(rules)));
         }
 
     }

--- a/components/proxy/src/main/java/com/hotels/styx/spi/JarResources.java
+++ b/components/proxy/src/main/java/com/hotels/styx/spi/JarResources.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.spi;
 
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.Resource;
 import com.hotels.styx.common.io.FileResource;
 import com.hotels.styx.common.io.FileResourceIndex;
@@ -23,6 +22,7 @@ import com.hotels.styx.common.io.FileResourceIndex;
 import java.nio.file.Path;
 import java.util.Collection;
 
+import static com.hotels.styx.javaconvenience.UtilKt.iterableToList;
 import static java.util.Collections.singleton;
 
 /**
@@ -54,6 +54,6 @@ final class JarResources {
 
     private static Collection<Resource> multipleResources(Path path) {
         FileResourceIndex resourceIndex = new FileResourceIndex();
-        return ImmutableList.copyOf(resourceIndex.list(path.toString(), ".jar"));
+        return iterableToList(resourceIndex.list(path.toString(), ".jar"));
     }
 }

--- a/components/proxy/src/test/java/com/hotels/styx/infrastructure/FileBackedRegistryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/infrastructure/FileBackedRegistryTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.infrastructure;
 
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.api.Resource;
 import com.hotels.styx.api.extension.service.BackendService;
 import com.hotels.styx.api.extension.service.spi.Registry;
@@ -26,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.List;
 
 import static com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.reloaded;
 import static com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.unchanged;
@@ -60,7 +60,7 @@ public class FileBackedRegistryTest {
     public void announcesInitialStateWhenStarts() throws IOException {
         Resource configurationFile = mockResource("/styx/config", new ByteArrayInputStream(originalContent));
 
-        registry = new FileBackedRegistry<>(configurationFile, bytes -> ImmutableList.of(backendService), any -> true);
+        registry = new FileBackedRegistry<>(configurationFile, bytes -> List.of(backendService), any -> true);
         registry.addListener(listener);
 
         await(registry.reload());
@@ -75,7 +75,7 @@ public class FileBackedRegistryTest {
                 new ByteArrayInputStream(originalContent)
         );
 
-        registry = new FileBackedRegistry<>(configurationFile, bytes -> ImmutableList.of(backendService), any -> true);
+        registry = new FileBackedRegistry<>(configurationFile, bytes -> List.of(backendService), any -> true);
         registry.addListener(listener);
         await(registry.reload());
         verify(listener).onChange(eq(changeSet().added(backendService).build()));
@@ -91,7 +91,7 @@ public class FileBackedRegistryTest {
     public void announcesNoMeaningfulChangesWhenNoSemanticChanges() throws Exception {
         Resource configurationFile = mockResource("/styx/config", new ByteArrayInputStream(originalContent));
 
-        registry = new FileBackedRegistry<>(configurationFile, bytes -> ImmutableList.of(backendService), any -> true);
+        registry = new FileBackedRegistry<>(configurationFile, bytes -> List.of(backendService), any -> true);
         registry.addListener(listener);
 
         await(registry.reload());
@@ -118,9 +118,9 @@ public class FileBackedRegistryTest {
                 configurationFile,
                 bytes -> {
                     if (new String(bytes).equals(new String(originalContent))) {
-                        return ImmutableList.of(backendService1);
+                        return List.of(backendService1);
                     } else {
-                        return ImmutableList.of(backendService2);
+                        return List.of(backendService2);
                     }
                 },
                 any -> true);
@@ -149,7 +149,7 @@ public class FileBackedRegistryTest {
                 configurationFile,
                 bytes -> {
                     if (new String(bytes).equals(new String(originalContent))) {
-                        return ImmutableList.of(backendService);
+                        return List.of(backendService);
                     } else {
                         throw new JustATestException();
                     }
@@ -173,7 +173,7 @@ public class FileBackedRegistryTest {
     public void modifyTimeProviderHandlesExceptions() throws Exception {
         registry = new FileBackedRegistry<>(
                 mockResource("/styx/config", new ByteArrayInputStream(originalContent)),
-                bytes -> ImmutableList.of(new BackendService.Builder().id("x").path("/x").build()),
+                bytes -> List.of(new BackendService.Builder().id("x").path("/x").build()),
                 any -> true
         );
 

--- a/components/proxy/src/test/java/com/hotels/styx/infrastructure/configuration/ConfigurationParserTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/infrastructure/configuration/ConfigurationParserTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.infrastructure.configuration;
 
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +41,7 @@ public class ConfigurationParserTest {
     public void setUp() {
         fakeFileSystem = new HashMap<>();
 
-        createStubConfig("/fake/base-config.yml", ImmutableMap.of(
+        createStubConfig("/fake/base-config.yml", Map.of(
                 "include", "/fake/parent-config.yml",
                 "number", 123,
                 "string", "abc",
@@ -50,14 +49,14 @@ public class ConfigurationParserTest {
                 "hasPlaceholder", "${string}"
         ));
 
-        createStubConfig("/fake/parent-config.yml", ImmutableMap.of(
+        createStubConfig("/fake/parent-config.yml", Map.of(
                 "numberFromParent", 111,
                 "stringFromParent", "DEF"));
     }
 
     @Test
     public void providesConfig() {
-        createStubConfig("/fake/simple-config.yml", ImmutableMap.of(
+        createStubConfig("/fake/simple-config.yml", Map.of(
                 "foo", 123,
                 "bar", "abc"));
 
@@ -122,7 +121,7 @@ public class ConfigurationParserTest {
     public void appliesOverrides() {
         ConfigurationParser<StubConfiguration> parser = new ConfigurationParser.Builder<StubConfiguration>()
                 .format(format)
-                .overrides(ImmutableMap.of("string", "overridden"))
+                .overrides(Map.of("string", "overridden"))
                 .build();
 
         StubConfiguration parsedConfiguration = parser.parse(configSource(newResource("/fake/base-config.yml")));
@@ -132,7 +131,7 @@ public class ConfigurationParserTest {
 
     @Test
     public void includeValueCanContainPlaceholder() {
-        createStubConfig("/test/base-config.yml", ImmutableMap.of(
+        createStubConfig("/test/base-config.yml", Map.of(
                 "include", "${include-placeholder}",
                 "number", 123,
                 "string", "abc",
@@ -140,13 +139,13 @@ public class ConfigurationParserTest {
                 "hasPlaceholder", "${string}"
         ));
 
-        createStubConfig("/test/parent-config.yml", ImmutableMap.of(
+        createStubConfig("/test/parent-config.yml", Map.of(
                 "numberFromParent", 111,
                 "stringFromParent", "DEF"));
 
         ConfigurationParser<StubConfiguration> parser = new ConfigurationParser.Builder<StubConfiguration>()
                 .format(format)
-                .overrides(ImmutableMap.of("include-placeholder", "/test/parent-config.yml"))
+                .overrides(Map.of("include-placeholder", "/test/parent-config.yml"))
                 .build();
 
         StubConfiguration parsedConfiguration = parser.parse(configSource(newResource("/test/base-config.yml")));
@@ -156,12 +155,12 @@ public class ConfigurationParserTest {
 
     @Test
     public void childCanReplaceParentPlaceholders() {
-        createStubConfig("/test/base-config.yml", ImmutableMap.of(
+        createStubConfig("/test/base-config.yml", Map.of(
                 "include", "/test/parent-config.yml",
                 "childString", "abc"
         ));
 
-        createStubConfig("/test/parent-config.yml", ImmutableMap.of(
+        createStubConfig("/test/parent-config.yml", Map.of(
                 "parentString", "${childString}"
         ));
 

--- a/components/proxy/src/test/java/com/hotels/styx/infrastructure/configuration/yaml/YamlConfigurationFormatTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/infrastructure/configuration/yaml/YamlConfigurationFormatTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.infrastructure.configuration.yaml;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -30,7 +29,7 @@ import static org.hamcrest.Matchers.is;
 public class YamlConfigurationFormatTest {
     @Test
     public void canResolvePlaceholdersInInclude() throws IOException {
-        Map<String, String> overrides = ImmutableMap.of("CONFIG_LOCATION", "some_location");
+        Map<String, String> overrides = Map.of("CONFIG_LOCATION", "some_location");
 
         String yaml = "${CONFIG_LOCATION:classpath:}/conf/environment/default.yaml";
 

--- a/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporterTest.java
@@ -27,7 +27,6 @@ import com.codahale.metrics.SlidingWindowReservoir;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.graphite.Graphite;
-import com.google.common.collect.ImmutableSortedMap;
 import com.hotels.styx.support.matchers.LoggingTestSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +41,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Function;
@@ -52,6 +53,7 @@ import static ch.qos.logback.classic.Level.ERROR;
 import static com.hotels.styx.metrics.reporting.graphite.GraphiteReporter.MAX_RETRIES;
 import static com.hotels.styx.metrics.reporting.graphite.GraphiteReporter.forRegistry;
 import static com.hotels.styx.support.matchers.LoggingEventMatcher.loggingEvent;
+import static java.util.Collections.emptySortedMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -429,11 +431,11 @@ public class GraphiteReporterTest {
 
 
     private static <T> SortedMap<String, T> emptyMap() {
-        return ImmutableSortedMap.of();
+        return emptySortedMap();
     }
 
     private static <T> SortedMap<String, T> map(String name, T metric) {
-        return ImmutableSortedMap.of(name, metric);
+        return Collections.unmodifiableSortedMap(new TreeMap<>(Map.of(name, metric)));
     }
 
     private static <T> Gauge<T> gauge(T value) {

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/StyxProxyTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/StyxProxyTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.proxy;
 
-import com.google.common.collect.ImmutableList;
 import com.hotels.styx.NettyExecutor;
 import com.google.common.util.concurrent.Service;
 import com.hotels.styx.InetServer;
@@ -40,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.common.StyxFutures.await;
@@ -78,7 +78,7 @@ public class StyxProxyTest extends SSLSetup {
                 .bossExecutor(NettyExecutor.create("Test-Server-Boss", 1))
                 .workerExecutor(NettyExecutor.create("Test-Server-Worker", 0))
                 .handler(new HttpInterceptorPipeline(
-                        ImmutableList.of(echoInterceptor),
+                        List.of(echoInterceptor),
                         (request, context) -> new HttpAggregator(new StandardHttpRouter()).handle(request, context),
                         false))
                 .build();

--- a/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/routing/handlers/PathPrefixRouterTest.java
@@ -16,28 +16,20 @@
 package com.hotels.styx.routing.handlers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.routing.RoutingObject;
-import com.hotels.styx.routing.config.Builtins;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
-import com.hotels.styx.routing.config.StyxObjectDefinition;
 import com.hotels.styx.routing.config.StyxObjectReference;
 import com.hotels.styx.server.NoServiceConfiguredException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -95,14 +87,13 @@ public class PathPrefixRouterTest {
         routingObjects.put(new StyxObjectReference("fooBarPathHandler"), fooBarPathHandler);
         routingObjects.put(new StyxObjectReference("fooBazFileHandler"), fooBazFileHandler);
 
-        PathPrefixRouter router = buildRouter(ImmutableMap.<String, String>builder()
-                .put("/", "rootHandler")
-                .put("/foo", "fooFileHandler")
-                .put("/foo/", "fooPathHandler")
-                .put("/foo/bar", "fooBarFileHandler")
-                .put("/foo/bar/", "fooBarPathHandler")
-                .put("/foo/baz", "fooBazFileHandler")
-                .build());
+        PathPrefixRouter router = buildRouter(Map.of(
+                "/", "rootHandler",
+                "/foo", "fooFileHandler",
+                "/foo/", "fooPathHandler",
+                "/foo/bar", "fooBarFileHandler",
+                "/foo/bar/", "fooBarPathHandler",
+                "/foo/baz", "fooBazFileHandler"));
 
         testRequestRoute(router, "/", rootHandler);
         testRequestRoute(router, "/foo", fooFileHandler);

--- a/components/proxy/src/test/java/com/hotels/styx/serviceproviders/ServiceProvisionTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/serviceproviders/ServiceProvisionTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.serviceproviders;
 
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.StyxConfig;
 import com.hotels.styx.api.Environment;
 import com.hotels.styx.api.MicrometerRegistry;
@@ -171,7 +170,7 @@ public class ServiceProvisionTest {
     public void servicesReturnCorrectlyFromCall() {
         Map<String, String> services = loadServices(environment.configuration(), environment, "multi", String.class);
 
-        assertThat(services, isMap(ImmutableMap.of(
+        assertThat(services, isMap(Map.of(
                 "one", "valueNumber1",
                 "two", "valueNumber2",
                 "three", "valueNumber3"

--- a/components/proxy/src/test/java/com/hotels/styx/startup/StyxServerComponentsTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/startup/StyxServerComponentsTest.java
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.startup;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.Environment;
 import com.hotels.styx.StyxConfig;
 import com.hotels.styx.api.Eventual;
@@ -68,7 +66,7 @@ public class StyxServerComponentsTest {
         StyxServerComponents components = new StyxServerComponents.Builder()
                 .registry(new MicrometerRegistry(new CompositeMeterRegistry()))
                 .styxConfig(new StyxConfig())
-                .pluginFactories(ImmutableList.of(f1, f2))
+                .pluginFactories(List.of(f1, f2))
                 .build();
 
         List<NamedPlugin> plugins = components.plugins();
@@ -82,7 +80,7 @@ public class StyxServerComponentsTest {
         StyxServerComponents components = new StyxServerComponents.Builder()
                 .registry(new MicrometerRegistry(new CompositeMeterRegistry()))
                 .styxConfig(new StyxConfig())
-                .services((env, routeDb) -> ImmutableMap.of(
+                .services((env, routeDb) -> Map.of(
                         "service1", mock(StyxService.class),
                         "service2", mock(StyxService.class)))
                 .build();
@@ -97,7 +95,7 @@ public class StyxServerComponentsTest {
         StyxServerComponents components = new StyxServerComponents.Builder()
                 .registry(new MicrometerRegistry((new CompositeMeterRegistry())))
                 .styxConfig(new StyxConfig())
-                .additionalServices(ImmutableMap.of(
+                .additionalServices(Map.of(
                         "service1", mock(StyxService.class),
                         "service2", mock(StyxService.class)))
                 .build();

--- a/components/proxy/src/test/kotlin/com/hotels/styx/Support.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/Support.kt
@@ -16,7 +16,6 @@
 package com.hotels.styx
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.google.common.collect.ImmutableSet
 import com.hotels.styx.api.*
 import com.hotels.styx.api.HttpResponse.response
 import com.hotels.styx.api.HttpResponseStatus.OK
@@ -33,7 +32,6 @@ import com.hotels.styx.routing.config.StyxObjectReference
 import com.hotels.styx.routing.db.StyxObjectStore
 import com.hotels.styx.routing.handlers.RouteRefLookup
 import com.hotels.styx.server.HttpInterceptorContext
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.CapturingSlot
 import io.mockk.every
@@ -90,7 +88,7 @@ fun executorObjects(): StyxObjectStore<StyxObjectRecord<NettyExecutor>> = StyxOb
             "Test-Client-Global-Worker".let { name ->
                 objectStore.insert("Styx-Client-Global-Worker", StyxObjectRecord(
                         "NettyExecutor",
-                        ImmutableSet.of("StyxInternal"),
+                        setOf("StyxInternal"),
                         NettyExecutorConfig(0, name).asJsonNode(),
                         NettyExecutor.create(name, 0)))
             }

--- a/components/server/src/test/java/com/hotels/styx/server/HttpsConnectorConfigTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/HttpsConnectorConfigTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.server;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -72,8 +71,8 @@ public class HttpsConnectorConfigTest {
         protocols[0] = "TLSv1.1";
         cipherSuites.add("A2");
 
-        assertThat(connector1.protocols(), equalTo(ImmutableList.of("TLSv1.2")));
-        assertThat(connector1.ciphers(), equalTo(ImmutableList.of("A1")));
+        assertThat(connector1.protocols(), equalTo(List.of("TLSv1.2")));
+        assertThat(connector1.ciphers(), equalTo(List.of("A1")));
     }
 
 

--- a/components/server/src/test/java/com/hotels/styx/server/netty/codec/NettyToStyxRequestDecoderTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/codec/NettyToStyxRequestDecoderTest.java
@@ -50,14 +50,13 @@ import reactor.test.StepVerifier;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.concurrent.CountDownLatch;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Sets.newHashSet;
 import static com.hotels.styx.api.RequestCookie.requestCookie;
+import static com.hotels.styx.javaconvenience.UtilKt.iterableToList;
 import static com.hotels.styx.server.UniqueIdSuppliers.fixedUniqueIdSupplier;
 import static com.hotels.styx.support.netty.HttpMessageSupport.httpMessageToBytes;
-import static com.hotels.styx.support.netty.HttpMessageSupport.httpRequest;
 import static com.hotels.styx.support.netty.HttpMessageSupport.httpRequestAsBuf;
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import static io.netty.handler.codec.http.HttpHeaders.Names.EXPECT;
@@ -275,7 +274,7 @@ public class NettyToStyxRequestDecoderTest {
                         requestCookie("guid", "xxxxx-xxx-xxx-xxx-xxxxxxx")
                 )
                 .build();
-        assertThat(newHashSet(styxRequest.cookies()), is(newHashSet(expected.cookies())));
+        assertThat(new HashSet<>(styxRequest.cookies()), is(new HashSet<>(expected.cookies())));
     }
 
     @Test
@@ -299,7 +298,7 @@ public class NettyToStyxRequestDecoderTest {
                         requestCookie("guid", "a,b")
                 )
                 .build();
-        assertThat(newHashSet(styxRequest.cookies()), is(newHashSet(expected.cookies())));
+        assertThat(new HashSet<>(styxRequest.cookies()), is(new HashSet<>(expected.cookies())));
     }
 
     @Test
@@ -333,7 +332,7 @@ public class NettyToStyxRequestDecoderTest {
     }
 
     private void assertThatHttpHeadersAreSame(Iterable<HttpHeader> headers, HttpHeaders headers1) {
-        assertThat(newArrayList(headers).size(), is(headers1.size()));
+        assertThat(iterableToList(headers).size(), is(headers1.size()));
         for (HttpHeader header : headers) {
             assertThat(header.value(), is(headers1.get(header.name())));
         }

--- a/components/server/src/test/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandlerTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandlerTest.java
@@ -58,14 +58,13 @@ import reactor.core.publisher.Mono;
 import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static ch.qos.logback.classic.Level.INFO;
 import static ch.qos.logback.classic.Level.WARN;
-import static com.google.common.collect.Iterables.concat;
-import static com.google.common.collect.Iterables.toArray;
 import static com.hotels.styx.api.HttpHeaderNames.CONNECTION;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_LENGTH;
 import static com.hotels.styx.api.HttpHeaderValues.CLOSE;
@@ -77,6 +76,7 @@ import static com.hotels.styx.api.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
 import static com.hotels.styx.api.HttpResponseStatus.REQUEST_TIMEOUT;
 import static com.hotels.styx.api.LiveHttpRequest.get;
 import static com.hotels.styx.api.LiveHttpResponse.response;
+import static com.hotels.styx.javaconvenience.UtilKt.append;
 import static com.hotels.styx.server.netty.connectors.HttpPipelineHandler.State.ACCEPTING_REQUESTS;
 import static com.hotels.styx.server.netty.connectors.HttpPipelineHandler.State.SENDING_RESPONSE;
 import static com.hotels.styx.server.netty.connectors.HttpPipelineHandler.State.SENDING_RESPONSE_CLIENT_CLOSED;
@@ -1031,12 +1031,14 @@ public class HttpPipelineHandlerTest {
     }
 
     private static EmbeddedChannel buildEmbeddedChannel(ChannelHandler... lastHandlers) {
-        Iterable<ChannelHandler> commonHandlers = asList(
+        List<ChannelHandler> commonHandlers = asList(
                 new HttpRequestDecoder(),
                 new HttpObjectAggregator(6000),
                 new NettyToStyxRequestDecoder.Builder().build());
 
-        return new EmbeddedChannel(toArray(concat(commonHandlers, asList(lastHandlers)), ChannelHandler.class));
+        ChannelHandler[] handlers = append(commonHandlers, lastHandlers).toArray(new ChannelHandler[0]);
+
+        return new EmbeddedChannel(handlers);
     }
 
     private double requestOutstandingValue(MeterRegistry registry) {

--- a/components/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
+++ b/components/test-api/src/main/java/com/hotels/styx/testapi/StyxServer.java
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.testapi;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.hotels.styx.StyxConfig;
 import com.hotels.styx.admin.AdminServerConfig;
 import com.hotels.styx.api.MetricRegistry;
@@ -67,7 +65,7 @@ public final class StyxServer {
                 .registry(new MicrometerRegistry(new CompositeMeterRegistry()))
                 .styxConfig(styxConfig(builder))
                 .pluginFactories(builder.pluginFactories)
-                .additionalServices(ImmutableMap.of("backendServiceRegistry", new RegistryServiceAdapter(backendServicesRegistry)))
+                .additionalServices(Map.of("backendServiceRegistry", new RegistryServiceAdapter(backendServicesRegistry)))
                 .build();
 
         metricRegistry = config.environment().metricRegistry();
@@ -157,7 +155,7 @@ public final class StyxServer {
 
         /**
          * Specifies the HTTP port for proxy server.
-         *
+         * <p>
          * By default, Styx will automatically allocate a free port number. This happens when a port is
          * not set a value on the builder, or it is set a value of 0 (zero).
          *
@@ -171,7 +169,7 @@ public final class StyxServer {
 
         /**
          * Specifies the HTTPS port for proxy server.
-         *
+         * <p>
          * By default, Styx will automatically allocate a free port number. This happens when a port is
          * not set a value on the builder, or it is set a value of 0 (zero).
          *
@@ -185,7 +183,7 @@ public final class StyxServer {
 
         /**
          * Specifies the HTTP port for admin server
-         *
+         * <p>
          * By default, Styx will automatically allocate a free port number. This happens when a port is
          * not set a value on the builder, or it is set a value of 0 (zero).
          *
@@ -234,7 +232,7 @@ public final class StyxServer {
          * @return this builder
          */
         public Builder addRoute(String pathPrefix, Origin... origins) {
-            return addRoute(pathPrefix, ImmutableSet.copyOf(origins));
+            return addRoute(pathPrefix, Set.of(origins));
         }
 
         /**

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/MetricsSnapshot.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/MetricsSnapshot.java
@@ -18,7 +18,6 @@ package com.hotels.styx.utils;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.client.HttpClient;
 import com.hotels.styx.client.StyxHttpClient;
@@ -87,10 +86,10 @@ public class MetricsSnapshot {
                 .map(value -> (int) value);
     }
 
-    public Optional<ImmutableMap<String, Object>> getMetric(String metricType, String metricName) {
+    public Optional<Map<String, Object>> getMetric(String metricType, String metricName) {
         return Optional.ofNullable((Map<String, Object>) tree.get(metricType))
                 .map(metersMap -> (Map<String, Object>) metersMap.get(metricName))
-                .map(ImmutableMap::copyOf);
+                .map(Map::copyOf);
     }
 
     @Override

--- a/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/servers/WiremockResponseConverterTest.java
+++ b/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/servers/WiremockResponseConverterTest.java
@@ -19,7 +19,6 @@ import com.github.tomakehurst.wiremock.http.BasicResponseRenderer;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.HttpHeader;
 import com.hotels.styx.api.HttpResponse;
 import org.junit.jupiter.api.Test;
@@ -65,7 +64,7 @@ public class WiremockResponseConverterTest {
         assertThat(styxResponse.status(), is(OK));
         Map<String, String> actual = headersAsMap(styxResponse);
 
-        assertThat(actual, is(ImmutableMap.of(
+        assertThat(actual, is(Map.of(
                 "Transfer-Encoding", "chunked",
                 "Content-Type", "application/json")));
         assertThat(styxResponse.bodyAs(UTF_8), is("{ \"count\" : 0, \"requestJournalDisabled\" : false}"));

--- a/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/support/origins/MetricsSnapshotTest.java
+++ b/system-tests/e2e-testsupport/src/test/java/com/hotels/styx/support/origins/MetricsSnapshotTest.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.support.origins;
 
 import com.codahale.metrics.json.MetricsModule;
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.admin.dashboard.JsonSupplier;
 import com.hotels.styx.api.metrics.codahale.CodaHaleMetricRegistry;
 import com.hotels.styx.api.metrics.codahale.NoopMetricRegistry;
@@ -24,6 +23,7 @@ import com.hotels.styx.utils.MetricsSnapshot;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -47,7 +47,7 @@ public class MetricsSnapshotTest {
     public void returnsMetricsIfAvailable() throws Exception {
         registry.meter("my.meter").mark();
 
-        Optional<ImmutableMap<String, Object>> meter = MetricsSnapshot.fromString(jsonSupplier.get())
+        Optional<Map<String, Object>> meter = MetricsSnapshot.fromString(jsonSupplier.get())
                 .getMetric("meters", "my.meter");
 
         assertThat(meter.isPresent(), is(true));
@@ -55,7 +55,7 @@ public class MetricsSnapshotTest {
 
     @Test
     public void returnsAbsentIfMetricIsNotAvailable() throws Exception {
-        Optional<ImmutableMap<String, Object>> meter = MetricsSnapshot.fromString(jsonSupplier.get())
+        Optional<Map<String, Object>> meter = MetricsSnapshot.fromString(jsonSupplier.get())
                 .getMetric("meters", "my.meter");
 
         assertThat(meter.isPresent(), is(false));
@@ -65,7 +65,7 @@ public class MetricsSnapshotTest {
     public void returnsAbsentIfWrongMetricsType() throws Exception {
         registry.meter("my.meter").mark();
 
-        Optional<ImmutableMap<String, Object>> meter = MetricsSnapshot.fromString(jsonSupplier.get())
+        Optional<Map<String, Object>> meter = MetricsSnapshot.fromString(jsonSupplier.get())
                 .getMetric("wrong type", "my.meter");
 
         assertThat(meter.isPresent(), is(false));

--- a/system-tests/example-backend-provider/src/main/java/testgrp/AdminHandlers.java
+++ b/system-tests/example-backend-provider/src/main/java/testgrp/AdminHandlers.java
@@ -15,9 +15,10 @@
  */
 package testgrp;
 
-import com.google.common.collect.ImmutableMap;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.Eventual;
+
+import java.util.Map;
 
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
@@ -28,8 +29,8 @@ final class AdminHandlers {
     private AdminHandlers() {
     }
 
-    static ImmutableMap<String, HttpHandler> adminHandlers(String endpoint, String responseContent) {
-        return ImmutableMap.of(endpoint, (request, context) -> Eventual.of(response(OK)
+    static Map<String, HttpHandler> adminHandlers(String endpoint, String responseContent) {
+        return Map.of(endpoint, (request, context) -> Eventual.of(response(OK)
                 .body(responseContent, UTF_8)
                 .build().stream()));
     }

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/support/StyxServerProvider.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/support/StyxServerProvider.kt
@@ -18,7 +18,6 @@ package com.hotels.styx.support
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.common.collect.ImmutableSet
 import com.hotels.styx.StyxConfig
 import com.hotels.styx.StyxServer
 import com.hotels.styx.api.*
@@ -104,7 +103,7 @@ class StyxServerProvider(
             stop()
         }
 
-        val meterRegistry = MicrometerRegistry(CompositeMeterRegistry(Clock.SYSTEM, ImmutableSet.of(SimpleMeterRegistry())))
+        val meterRegistry = MicrometerRegistry(CompositeMeterRegistry(Clock.SYSTEM, setOf(SimpleMeterRegistry())))
         var components = StyxServerComponents.Builder()
                 .registry(meterRegistry)
                 .styxConfig(StyxConfig.fromYaml(configuration, validateConfig))

--- a/system-tests/styx-test-plugin/src/main/java/loadtest/plugins/AdminHandlers.java
+++ b/system-tests/styx-test-plugin/src/main/java/loadtest/plugins/AdminHandlers.java
@@ -15,9 +15,10 @@
  */
 package loadtest.plugins;
 
-import com.google.common.collect.ImmutableMap;
-import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.Eventual;
+import com.hotels.styx.api.HttpHandler;
+
+import java.util.Map;
 
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
@@ -28,8 +29,8 @@ final class AdminHandlers {
     private AdminHandlers() {
     }
 
-    static ImmutableMap<String, HttpHandler> adminHandlers(String endpoint, String responseContent) {
-        return ImmutableMap.of(endpoint, (request, context) -> Eventual.of(response(OK)
+    static Map<String, HttpHandler> adminHandlers(String endpoint, String responseContent) {
+        return Map.of(endpoint, (request, context) -> Eventual.of(response(OK)
                 .body(responseContent, UTF_8)
                 .build()
                 .stream()


### PR DESCRIPTION
To reduce the need to continually update third-party dependencies for security vulnerabilities, we can remove dependencies we don't need. Reduced dependencies are also good for Styx, as it is a plugin framework and dependencies can clash with plugins.

Removing Guava entirely would be a very big PR, so this PR merely reduces it, targeting the use of Guava collections in particular. Future PRs will remove more.

Many of the Guava methods used are now replicated (or sufficiently approximated) by the Java standard library. Others are easy to implement ourselves, and a few were never needed to begin with. 

These method calls have been replaced or removed.