### PR TITLE
Replace purely cosmetic annotation with comment

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/Url.java
+++ b/components/api/src/main/java/com/hotels/styx/api/Url.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.api;
 
-import com.google.common.annotations.VisibleForTesting;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.net.MalformedURLException;
@@ -174,7 +173,7 @@ public final class Url implements Comparable<Url> {
         }
     }
 
-    @VisibleForTesting
+    // Visible for testing
     Optional<UrlQuery> query() {
         return this.query;
     }

--- a/components/client/src/main/java/com/hotels/styx/client/OriginRestrictionLoadBalancingStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/OriginRestrictionLoadBalancingStrategy.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.extension.ActiveOrigins;
 import com.hotels.styx.api.extension.RemoteHost;
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancer;
@@ -50,7 +49,7 @@ public class OriginRestrictionLoadBalancingStrategy implements LoadBalancer {
         this(activeOrigins, delegate, new Random());
     }
 
-    @VisibleForTesting
+    // Visible for testing
     OriginRestrictionLoadBalancingStrategy(ActiveOrigins activeOrigins, LoadBalancer delegate, Random rng) {
         this.activeOrigins = activeOrigins;
         this.delegate = requireNonNull(delegate);

--- a/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/OriginsInventory.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.hotels.styx.api.Eventual;
@@ -147,7 +146,7 @@ public final class OriginsInventory
         eventQueue.submit(new SetOriginsEvent(newOrigins));
     }
 
-    @VisibleForTesting
+    // Visible for testing
     public void setOrigins(Origin... origins) {
         setOrigins(Set.of(origins));
     }

--- a/components/client/src/main/java/com/hotels/styx/client/StyxHttpClient.java
+++ b/components/client/src/main/java/com/hotels/styx/client/StyxHttpClient.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HostAndPort;
 import com.hotels.styx.NettyExecutor;
 import com.hotels.styx.api.HttpRequest;
@@ -111,7 +110,7 @@ public final class StyxHttpClient implements HttpClient {
                 .toFuture();
     }
 
-    @VisibleForTesting
+    // Visible for testing
     static Mono<LiveHttpResponse> sendRequestInternal(NettyConnectionFactory connectionFactory, LiveHttpRequest request, Builder params) {
         LiveHttpRequest networkRequest = addUserAgent(params.userAgent(), request);
         Origin origin = originFromRequest(networkRequest, params.https());

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/SimpleConnectionPool.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client.connectionpool;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
 import com.hotels.styx.client.Connection;
@@ -132,7 +131,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
         }
     }
 
-    @VisibleForTesting
+    // Visible for testing
     Connection dequeue() {
         Connection connection = availableConnections.poll();
 
@@ -220,7 +219,7 @@ public class SimpleConnectionPool implements ConnectionPool, Connection.Listener
         return this.stats;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     private class ConnectionPoolStats implements Stats {
 
         @Override

--- a/components/client/src/main/java/com/hotels/styx/client/healthcheck/monitors/ScheduledOriginHealthStatusMonitor.java
+++ b/components/client/src/main/java/com/hotels/styx/client/healthcheck/monitors/ScheduledOriginHealthStatusMonitor.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client.healthcheck.monitors;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.extension.Announcer;
 import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.extension.service.spi.AbstractStyxService;
@@ -73,7 +72,7 @@ public class ScheduledOriginHealthStatusMonitor extends AbstractStyxService impl
         this.origins = new ConcurrentSkipListSet<>();
     }
 
-    @VisibleForTesting
+    // Visible for testing
     OriginHealthStatusMonitor monitor(Origin... origins) {
         return monitor(Set.of(origins));
     }

--- a/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategy.java
+++ b/components/client/src/main/java/com/hotels/styx/client/loadbalancing/strategies/PowerOfTwoStrategy.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.client.loadbalancing.strategies;
 
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.Environment;
 import com.hotels.styx.api.extension.ActiveOrigins;
 import com.hotels.styx.api.extension.RemoteHost;
@@ -39,7 +38,7 @@ public class PowerOfTwoStrategy implements LoadBalancer {
     private final ActiveOrigins activeOrigins;
     private final Random rng;
 
-    @VisibleForTesting
+    // Visible for testing
     PowerOfTwoStrategy(ActiveOrigins activeOrigins, Random rng) {
         this.activeOrigins = requireNonNull(activeOrigins);
         this.rng = requireNonNull(rng);

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/HttpRequestOperation.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/HttpRequestOperation.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client.netty.connectionpool;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.Buffers;
 import com.hotels.styx.api.HttpMethod;
 import com.hotels.styx.api.HttpVersion;
@@ -86,7 +85,7 @@ public class HttpRequestOperation {
         this.httpRequestMessageLogger = new HttpRequestMessageLogger("com.hotels.styx.http-messages.outbound", longFormat, httpMessageFormatter);
     }
 
-    @VisibleForTesting
+    // Visible for testing
     static DefaultHttpRequest toNettyRequest(LiveHttpRequest request) {
         HttpVersion version = request.version();
         HttpMethod method = request.method();

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagator.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyToStyxResponsePropagator.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client.netty.connectionpool;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.Buffer;
 import com.hotels.styx.api.ByteStream;
 import com.hotels.styx.api.LiveHttpRequest;
@@ -208,7 +207,7 @@ final class NettyToStyxResponsePropagator extends SimpleChannelInboundHandler {
         }
     }
 
-    @VisibleForTesting
+    // Visible for testing
     static LiveHttpResponse.Builder toStyxResponse(io.netty.handler.codec.http.HttpResponse nettyResponse) {
         LiveHttpResponse.Builder responseBuilder = response(statusWithCode(nettyResponse.getStatus().code()));
 

--- a/components/common/src/main/java/com/hotels/styx/common/content/FlowControllingHttpContentProducer.java
+++ b/components/common/src/main/java/com/hotels/styx/common/content/FlowControllingHttpContentProducer.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.common.content;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.common.StateMachine;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.EventLoop;
@@ -489,7 +488,7 @@ public class FlowControllingHttpContentProducer {
         }
     }
 
-    @VisibleForTesting
+    // Visible for testing
     ProducerState state() {
         return stateMachine.currentState();
     }

--- a/components/common/src/main/java/com/hotels/styx/server/HttpInterceptorContext.java
+++ b/components/common/src/main/java/com/hotels/styx/server/HttpInterceptorContext.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.server;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.HttpInterceptor;
 
 import java.net.InetSocketAddress;
@@ -50,7 +49,7 @@ public final class HttpInterceptorContext implements HttpInterceptor.Context {
      * @deprecated use the constructor instead.
      * @return
      */
-    @VisibleForTesting
+    // Visible for testing
     @Deprecated
     public static HttpInterceptor.Context create() {
         return new HttpInterceptorContext(false, null, Runnable::run);

--- a/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
+++ b/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
@@ -20,15 +20,10 @@ import kotlin.streams.asStream
 
 /*
  * Note: although written in Kotlin, these convenience methods are intended to be used by Java code.
-<<<<<<< HEAD
  *
  * This has the following effects:
  * - Some functions seem redundant as they wrap a single kotlin function (the kotlin function doesn't exist in Java)
  * - Some language features that make Kotlin development easier are not used. For example: extension methods, this-receivers.
-=======
- * As such, certain language features that make Kotlin development easier will have no benefit in Java (or possibly make things more complicated),
- * for example, extension methods, this-receivers.
->>>>>>> WIP
  */
 
 fun <T> iteratorToList(iterator: Iterator<T>): List<T> = Iterable {

--- a/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
+++ b/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
@@ -20,10 +20,15 @@ import kotlin.streams.asStream
 
 /*
  * Note: although written in Kotlin, these convenience methods are intended to be used by Java code.
+<<<<<<< HEAD
  *
  * This has the following effects:
  * - Some functions seem redundant as they wrap a single kotlin function (the kotlin function doesn't exist in Java)
  * - Some language features that make Kotlin development easier are not used. For example: extension methods, this-receivers.
+=======
+ * As such, certain language features that make Kotlin development easier will have no benefit in Java (or possibly make things more complicated),
+ * for example, extension methods, this-receivers.
+>>>>>>> WIP
  */
 
 fun <T> iteratorToList(iterator: Iterator<T>): List<T> = Iterable {

--- a/components/proxy/src/main/java/com/hotels/styx/admin/CachingSupplier.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/CachingSupplier.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.admin;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.Clock;
 import org.slf4j.Logger;
 
@@ -59,7 +58,7 @@ public class CachingSupplier<E> implements Supplier<E> {
      * @param updateInterval interval between calls to sourceSupplier
      * @param clock allows you to specify a different clock (for testing).
      */
-    @VisibleForTesting
+    // Visible for testing
     public CachingSupplier(Supplier<? extends E> sourceSupplier, Duration updateInterval, Clock clock) {
         this.sourceSupplier = requireNonNull(sourceSupplier);
         this.updateIntervalMillis = updateInterval.toMillis();

--- a/components/proxy/src/main/java/com/hotels/styx/admin/dashboard/DashboardData.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/dashboard/DashboardData.java
@@ -20,7 +20,6 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -151,17 +150,17 @@ public class DashboardData {
             return backends;
         }
 
-        @VisibleForTesting
+        // Visible for testing
         Backend firstBackend() {
             return backends().stream().findFirst().get();
         }
 
-        @VisibleForTesting
+        // Visible for testing
         List<String> backendIds() {
             return backends().stream().map(Backend::id).collect(toList());
         }
 
-        @VisibleForTesting
+        // Visible for testing
         Backend backend(String backendId) {
             return backends().stream()
                     .filter(backend -> backend.id().equals(backendId))
@@ -267,7 +266,7 @@ public class DashboardData {
             return connectionsPoolsAggregate;
         }
 
-        @VisibleForTesting
+        // Visible for testing
         List<String> originsStatuses() {
             return origins()
                     .stream()
@@ -275,19 +274,19 @@ public class DashboardData {
                     .collect(toList());
         }
 
-        @VisibleForTesting
+        // Visible for testing
         Map<String, String> statusesByOriginId() {
             return origins().stream().collect(toMap(Origin::id, Origin::status));
         }
 
-        @VisibleForTesting
+        // Visible for testing
         Origin origin(String originId) {
             return origins().stream()
                     .filter(origin -> origin.id().equals(originId))
                     .findFirst().get();
         }
 
-        @VisibleForTesting
+        // Visible for testing
         Origin firstOrigin() {
             return origins().stream()
                     .findFirst().get();

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/JsonHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/JsonHandler.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.admin.handlers;
 
 import com.fasterxml.jackson.databind.Module;
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.admin.CachingSupplier;
 import com.hotels.styx.admin.dashboard.JsonSupplier;
 import com.hotels.styx.admin.handlers.json.JsonReformatter;
@@ -75,7 +74,7 @@ public class JsonHandler<E> extends BaseHttpHandler {
         this(dataSupplier, cacheExpiration, systemClock(), modules);
     }
 
-    @VisibleForTesting
+    // Visible for testing
     JsonHandler(Supplier<E> dataSupplier, Optional<Duration> cacheExpiration, Clock clock, Module... modules) {
         if (cacheExpiration.isPresent()) {
             LOG.debug("{} instantiated with cache expiration of {}", getClass().getSimpleName(), cacheExpiration.get());

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/FileBackedRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/FileBackedRegistry.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.infrastructure;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.HashCode;
 import com.hotels.styx.api.Identifiable;
 import com.hotels.styx.api.Resource;
@@ -64,7 +63,7 @@ public class FileBackedRegistry<T extends Identifiable> extends AbstractRegistry
         this.modifyTimeSupplier = modifyTimeSupplier;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     FileBackedRegistry(Resource configurationFile, Reader<T> reader, Supplier<FileTime> modifyTimeSupplier) {
         this(configurationFile, reader, modifyTimeSupplier, any -> true);
     }

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/yaml/PlaceholderResolver.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/yaml/PlaceholderResolver.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.infrastructure.configuration.UnresolvedPlaceholder;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonTreeTraversal.JsonTreeVisitor;
 import org.slf4j.Logger;
@@ -189,12 +188,12 @@ public class PlaceholderResolver {
         return list.get(list.size() - 1);
     }
 
-    @VisibleForTesting
+    // Visible for testing
     public static String replacePlaceholder(String originalString, String placeholderName, String placeholderValue) {
         return originalString.replaceAll("\\$\\{" + quote(placeholderName) + "(?:\\:[^\\}]*?)?\\}", placeholderValue);
     }
 
-    @VisibleForTesting
+    // Visible for testing
     static List<String> extractPlaceholderStrings(String value) {
         Matcher matcher = PLACEHOLDER_REGEX_CAPTURE_ALL.matcher(value);
 
@@ -207,7 +206,7 @@ public class PlaceholderResolver {
         return placeholders;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     public static List<Placeholder> extractPlaceholders(String value) {
         List<Placeholder> namesAndDefaults = new ArrayList<>();
 

--- a/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporter.java
+++ b/components/proxy/src/main/java/com/hotels/styx/metrics/reporting/graphite/GraphiteReporter.java
@@ -13,7 +13,6 @@ import com.codahale.metrics.ScheduledReporter;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.graphite.GraphiteSender;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -154,7 +153,7 @@ public class GraphiteReporter extends ScheduledReporter {
 
     private static final Logger LOGGER = getLogger(GraphiteReporter.class);
 
-    @VisibleForTesting
+    // Visible for testing
     static final int MAX_RETRIES = 5;
 
     private final GraphiteSender graphite;
@@ -257,7 +256,7 @@ public class GraphiteReporter extends ScheduledReporter {
         }
     }
 
-    @VisibleForTesting
+    // Visible for testing
     void initConnection() {
         tryTimes(
                 MAX_RETRIES,

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistry.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.Environment;
 import com.hotels.styx.api.Resource;
 import com.hotels.styx.api.configuration.Configuration;
@@ -58,14 +57,14 @@ public class FileBackedBackendServicesRegistry extends AbstractStyxService imple
     private final FileBackedRegistry<BackendService> fileBackedRegistry;
     private final FileMonitor fileChangeMonitor;
 
-    @VisibleForTesting
+    // Visible for testing
     FileBackedBackendServicesRegistry(FileBackedRegistry<BackendService> fileBackedRegistry, FileMonitor fileChangeMonitor) {
         super(format("FileBackedBackendServiceRegistry(%s)", fileBackedRegistry.fileName()));
         this.fileBackedRegistry = requireNonNull(fileBackedRegistry);
         this.fileChangeMonitor = requireNonNull(fileChangeMonitor);
     }
 
-    @VisibleForTesting
+    // Visible for testing
     FileBackedBackendServicesRegistry(Resource originsFile, FileMonitor fileChangeMonitor) {
         this(new FileBackedRegistry<>(
                         originsFile,
@@ -123,7 +122,7 @@ public class FileBackedBackendServicesRegistry extends AbstractStyxService imple
         return super.stop();
     }
 
-    @VisibleForTesting
+    // Visible for testing
     FileMonitor monitor() {
         return fileChangeMonitor;
     }
@@ -181,7 +180,7 @@ public class FileBackedBackendServicesRegistry extends AbstractStyxService imple
         }
     }
 
-    @VisibleForTesting
+    // Visible for testing
     static class YAMLBackendServicesReader implements FileBackedRegistry.Reader<BackendService> {
         private static final ObjectMapper MAPPER = addStyxMixins(new ObjectMapper(new YAMLFactory()))
                 .disable(FAIL_ON_UNKNOWN_PROPERTIES)
@@ -206,7 +205,7 @@ public class FileBackedBackendServicesRegistry extends AbstractStyxService imple
         }
     }
 
-    @VisibleForTesting
+    // Visible for testing
     static class RejectDuplicatePaths implements Predicate<Collection<BackendService>> {
         @Override
         public boolean test(Collection<BackendService> backendServices) {

--- a/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileChangeMonitor.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/backends/file/FileChangeMonitor.java
@@ -17,7 +17,6 @@ package com.hotels.styx.proxy.backends.file;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.HashCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,7 +141,7 @@ public class FileChangeMonitor implements FileMonitor {
         }
     }
 
-    @VisibleForTesting
+    // Visible for testing
     static class FileMonitorSettings {
         private final boolean enabled;
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/StaticPipelineFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/StaticPipelineFactory.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.routing;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.Environment;
 import com.hotels.styx.NettyExecutor;
 import com.hotels.styx.api.extension.service.BackendService;
@@ -41,7 +40,7 @@ public class StaticPipelineFactory {
     private final NettyExecutor executor;
     private final boolean trackRequests;
 
-    @VisibleForTesting
+    // Visible for testing
     StaticPipelineFactory(BackendServiceClientFactory clientFactory,
                           Environment environment,
                           Registry<BackendService> registry,

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/BackendServiceProxy.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/BackendServiceProxy.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.routing.handlers;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.Environment;
 import com.hotels.styx.NettyExecutor;
 import com.hotels.styx.api.Eventual;
@@ -79,7 +78,7 @@ public class BackendServiceProxy implements RoutingObject {
             return new StyxBackendServiceClientFactory(environment);
         }
 
-        @VisibleForTesting
+        // Visible for testing
         Factory(Environment environment, BackendServiceClientFactory serviceClientFactory, Map<String, Registry<BackendService>> backendRegistries) {
             this.serviceClientFactory = serviceClientFactory;
             this.backendRegistries = backendRegistries;

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.routing.handlers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HostAndPort;
 import com.hotels.styx.NettyExecutor;
 import com.hotels.styx.api.Eventual;
@@ -116,9 +115,9 @@ public class HostProxy implements RoutingObject {
     private final OriginMetrics originMetrics;
     private volatile boolean active = true;
 
-    @VisibleForTesting
+    // Visible for testing
     final String host;
-    @VisibleForTesting
+    // Visible for testing
     final int port;
 
     public HostProxy(String host, int port, StyxHostHttpClient client, OriginMetrics originMetrics) {

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/ProxyToBackend.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.routing.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.NettyExecutor;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
@@ -78,7 +77,7 @@ public class ProxyToBackend implements RoutingObject {
      * ProxyToBackend factory that instantiates an object from the Yaml configuration.
      */
     public static class Factory implements RoutingObjectFactory {
-        @VisibleForTesting
+        // Visible for testing
         static RoutingObject build(List<String> parents, Context context, StyxObjectDefinition configBlock, BackendServiceClientFactory clientFactory) {
             JsonNodeConfig jsConfig = new JsonNodeConfig(configBlock.config());
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StandardHttpPipeline.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/StandardHttpPipeline.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.routing.handlers;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
@@ -39,7 +38,7 @@ class StandardHttpPipeline implements HttpHandler {
     private final HttpHandler handler;
     private final RequestTracker requestTracker;
 
-    @VisibleForTesting
+    // Visible for testing
     public StandardHttpPipeline(HttpHandler handler) {
         this(emptyList(), handler, RequestTracker.NO_OP);
     }

--- a/components/proxy/src/main/java/com/hotels/styx/spi/ExtensionObjectFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/spi/ExtensionObjectFactory.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.spi;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.spi.config.SpiExtensionFactory;
 
 import java.nio.file.Paths;
@@ -38,7 +37,7 @@ public class ExtensionObjectFactory {
         this(ExtensionObjectFactory::locateExtension);
     }
 
-    @VisibleForTesting
+    // Visible for testing
     ExtensionObjectFactory(Function<SpiExtensionFactory, ClassSource> extensionLocator) {
         this.extensionLocator = requireNonNull(extensionLocator);
     }

--- a/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/StyxServerComponents.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.startup;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.AsyncEventBus;
 import com.hotels.styx.Environment;
 import com.hotels.styx.InetServer;
@@ -318,13 +317,13 @@ public class StyxServerComponents {
             return this;
         }
 
-        @VisibleForTesting
+        // Visible for testing
         public Builder loggingSetUp(String logConfigLocation) {
             this.loggingSetUp = env -> initLogging(logConfigLocation, true);
             return this;
         }
 
-        @VisibleForTesting
+        // Visible for testing
         public Builder plugins(Map<String, Plugin> plugins) {
             return pluginFactories(stubFactories(plugins));
         }
@@ -344,13 +343,13 @@ public class StyxServerComponents {
             return this;
         }
 
-        @VisibleForTesting
+        // Visible for testing
         Builder services(ServicesLoader servicesLoader) {
             this.servicesLoader = requireNonNull(servicesLoader);
             return this;
         }
 
-        @VisibleForTesting
+        // Visible for testing
         public Builder additionalServices(Map<String, StyxService> services) {
             this.additionalServices.putAll(services);
             return this;
@@ -361,7 +360,7 @@ public class StyxServerComponents {
             return this;
         }
 
-        @VisibleForTesting
+        // Visible for testing
         public Builder additionalRoutingObjects(Map<String, RoutingObjectFactory> additionalRoutingObjectFactories) {
             this.additionalRoutingObjectFactories.putAll(additionalRoutingObjectFactories);
             return this;

--- a/components/proxy/src/main/java/com/hotels/styx/startup/extensions/ConfiguredPluginFactory.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/extensions/ConfiguredPluginFactory.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.startup.extensions;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.plugins.spi.PluginFactory;
 
 import java.util.function.Function;
@@ -41,7 +40,7 @@ public class ConfiguredPluginFactory {
         this(name, pluginFactory, any -> null);
     }
 
-    @VisibleForTesting
+    // Visible for testing
     public ConfiguredPluginFactory(String name, PluginFactory pluginFactory, Object pluginConfig) {
         this(name, pluginFactory, type -> type.cast(pluginConfig));
     }

--- a/components/server/src/main/java/com/hotels/styx/server/netty/codec/NettyToStyxRequestDecoder.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/codec/NettyToStyxRequestDecoder.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.server.netty.codec;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.Buffer;
 import com.hotels.styx.api.ByteStream;
 import com.hotels.styx.api.HttpVersion;
@@ -176,7 +175,7 @@ public final class NettyToStyxRequestDecoder extends MessageToMessageDecoder<Htt
         return true;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     LiveHttpRequest.Builder makeAStyxRequestFrom(HttpRequest request, Publisher<Buffer> content) {
         Url url = UrlDecoder.decodeUrl(unwiseCharEncoder, request);
         LiveHttpRequest.Builder requestBuilder = new LiveHttpRequest.Builder()

--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.server.netty.connectors;
 
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hotels.styx.api.Buffer;
 import com.hotels.styx.api.ByteStream;
 import com.hotels.styx.api.ContentOverflowException;
@@ -197,7 +196,7 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
         return state;
     }
 
-    @VisibleForTesting
+    // Visible for testing
     State state() {
         return this.stateMachine.currentState();
     }


### PR DESCRIPTION
This is a continuation of the Guava removal https://github.com/ExpediaGroup/styx/pull/755

> To reduce the need to continually update third-party dependencies for security vulnerabilities, we can remove dependencies we don't need. Reduced dependencies are also good for Styx, as it is a plugin framework and dependencies can clash with plugins.
> 
> Removing Guava entirely would be a very big PR, so this PR merely reduces it, targeting the use of Guava collections in particular. Future PRs will remove more.
> 
> Many of the Guava methods used are now replicated (or sufficiently approximated) by the Java standard library. Others are easy to implement ourselves, and a few were never needed to begin with.
> 
> These method calls have been replaced or removed.