### PR TITLE
Remove use of Guava MediaType

### DIFF
--- a/components/api/src/main/java/com/hotels/styx/api/HttpHeaderValues.java
+++ b/components/api/src/main/java/com/hotels/styx/api/HttpHeaderValues.java
@@ -15,20 +15,18 @@
  */
 package com.hotels.styx.api;
 
-import io.netty.handler.codec.http.HttpHeaders.Values;
-
-import static io.netty.handler.codec.http.HttpHeaders.newEntity;
+import io.netty.util.AsciiString;
 
 /**
  * Provides optimized constants for the standard HTTP header values.
  */
 public final class HttpHeaderValues {
-    public static final CharSequence PLAIN_TEXT = newEntity("text/plain; charset=utf-8");
-    public static final CharSequence HTML = newEntity("text/html; charset=UTF-8");
-    public static final CharSequence APPLICATION_JSON = newEntity("application/json; charset=utf-8");
-    public static final CharSequence CLOSE = newEntity(Values.CLOSE);
-    public static final CharSequence KEEP_ALIVE = newEntity(Values.KEEP_ALIVE);
-    public static final CharSequence CHUNKED = newEntity(Values.CHUNKED);
+    public static final CharSequence PLAIN_TEXT = new AsciiString("text/plain; charset=utf-8");
+    public static final CharSequence HTML = new AsciiString("text/html; charset=UTF-8");
+    public static final CharSequence APPLICATION_JSON = new AsciiString("application/json; charset=utf-8");
+    public static final CharSequence CLOSE = io.netty.handler.codec.http.HttpHeaderValues.CLOSE;
+    public static final CharSequence KEEP_ALIVE = io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE;
+    public static final CharSequence CHUNKED = io.netty.handler.codec.http.HttpHeaderValues.CHUNKED;
 
     private HttpHeaderValues() {
     }

--- a/components/common/src/main/java/com/hotels/styx/common/http/handler/HttpContentHandler.java
+++ b/components/common/src/main/java/com/hotels/styx/common/http/handler/HttpContentHandler.java
@@ -35,10 +35,10 @@ import static java.util.Objects.requireNonNull;
 public class HttpContentHandler implements HttpHandler {
 
     private final Supplier<String> content;
-    private final String contentType;
+    private final CharSequence contentType;
     private final Charset encoding;
 
-    public HttpContentHandler(String contentType, Charset encoding, Supplier<String> content) {
+    public HttpContentHandler(CharSequence contentType, Charset encoding, Supplier<String> content) {
         this.content = requireNonNull(content, "content supplier cannot be null");
         this.contentType = requireNonNull(contentType, "contentType cannot be null");
         this.encoding = requireNonNull(encoding, "encoding cannot be null");

--- a/components/common/src/main/java/com/hotels/styx/common/http/handler/StaticBodyHttpHandler.java
+++ b/components/common/src/main/java/com/hotels/styx/common/http/handler/StaticBodyHttpHandler.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.common.http.handler;
 
-import com.google.common.net.MediaType;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
@@ -32,7 +31,7 @@ import static java.util.Objects.requireNonNull;
  * HTTP handler that responds with a static body.
  */
 public class StaticBodyHttpHandler extends BaseHttpHandler {
-    private final MediaType contentType;
+    private final CharSequence contentType;
     private final String body;
     private final int contentLength;
 
@@ -42,7 +41,7 @@ public class StaticBodyHttpHandler extends BaseHttpHandler {
      * @param contentType Content-Type header value
      * @param body        body to return
      */
-    public StaticBodyHttpHandler(MediaType contentType, String body) {
+    public StaticBodyHttpHandler(CharSequence contentType, String body) {
         this(contentType, body, UTF_8);
     }
 
@@ -53,7 +52,7 @@ public class StaticBodyHttpHandler extends BaseHttpHandler {
      * @param body        body to return
      * @param charset     character set
      */
-    public StaticBodyHttpHandler(MediaType contentType, String body, Charset charset) {
+    public StaticBodyHttpHandler(CharSequence contentType, String body, Charset charset) {
         this.contentType = requireNonNull(contentType);
         this.body = requireNonNull(body);
         this.contentLength = body.getBytes(charset).length;

--- a/components/common/src/test/java/com/hotels/styx/common/http/handler/StaticBodyHttpHandlerTest.java
+++ b/components/common/src/test/java/com/hotels/styx/common/http/handler/StaticBodyHttpHandlerTest.java
@@ -20,7 +20,7 @@ import com.hotels.styx.api.HttpResponse;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.support.Support.requestContext;
 import static com.hotels.styx.api.HttpRequest.get;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
@@ -32,12 +32,12 @@ import static org.hamcrest.Matchers.is;
 public class StaticBodyHttpHandlerTest {
     @Test
     public void respondsWithStaticBody() {
-        StaticBodyHttpHandler handler = new StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, "foo", UTF_8);
+        StaticBodyHttpHandler handler = new StaticBodyHttpHandler(PLAIN_TEXT.toString(), "foo", UTF_8);
 
         HttpResponse response = Mono.from(handler.handle(get("/").build(), requestContext())).block();
 
         assertThat(response.status(), is(OK));
-        assertThat(response.contentType(), isValue(PLAIN_TEXT_UTF_8.toString()));
+        assertThat(response.contentType(), isValue(PLAIN_TEXT.toString()));
         assertThat(response.contentLength(), isValue(length("foo")));
         assertThat(response.bodyAs(UTF_8), is("foo"));
     }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/AdminServerBuilder.java
@@ -74,8 +74,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import static com.google.common.net.MediaType.HTML_UTF_8;
 import static com.hotels.styx.admin.handlers.IndexHandler.Link.link;
+import static com.hotels.styx.api.HttpHeaderValues.HTML;
 import static com.hotels.styx.api.HttpMethod.POST;
 import static com.hotels.styx.metrics.MetricsExtensionsKt.findRegistry;
 import static com.hotels.styx.routing.config.ConfigVersionResolver.Version.ROUTING_CONFIG_V1;
@@ -256,7 +256,7 @@ public class AdminServerBuilder {
                 .collect(toList());
 
         WebServiceHandler handler = endpointLinks.isEmpty()
-                ? new StaticBodyHttpHandler(HTML_UTF_8, format("This plugin (%s) does not expose any admin interfaces", name))
+                ? new StaticBodyHttpHandler(HTML, format("This plugin (%s) does not expose any admin interfaces", name))
                 : new IndexHandler(endpointLinks);
 
         Route indexRoute = new Route(adminPath(root, name), new HttpAggregator(MEGABYTE, handler));

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/CurrentRequestsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/CurrentRequestsHandler.java
@@ -26,8 +26,8 @@ import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
@@ -56,7 +56,7 @@ public class CurrentRequestsHandler extends BaseHttpHandler {
         return HttpResponse
                 .response(OK)
                 .disableCaching()
-                .header(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                .header(CONTENT_TYPE, PLAIN_TEXT)
                 .body(getCurrentRequestContent(withStackTrace), UTF_8, true)
                 .build();
     }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/IndexHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/IndexHandler.java
@@ -21,8 +21,8 @@ import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.common.http.handler.BaseHttpHandler;
 
 import static com.google.common.net.HttpHeaders.CONTENT_LANGUAGE;
-import static com.google.common.net.MediaType.HTML_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.HTML;
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static java.lang.String.format;
@@ -59,7 +59,7 @@ public class IndexHandler extends BaseHttpHandler {
     @Override
     protected HttpResponse doHandle(HttpRequest request, HttpInterceptor.Context context) {
         return response(OK)
-                .addHeader(CONTENT_TYPE, HTML_UTF_8.toString())
+                .addHeader(CONTENT_TYPE, HTML)
                 .header(CONTENT_LANGUAGE, "en")
                 .body(html, UTF_8)
                 .build();

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/JsonHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/JsonHandler.java
@@ -30,9 +30,9 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static com.google.common.net.MediaType.JSON_UTF_8;
 import static com.hotels.styx.api.Clocks.systemClock;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.APPLICATION_JSON;
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
@@ -94,7 +94,7 @@ public class JsonHandler<E> extends BaseHttpHandler {
 
             return response(OK)
                     .disableCaching()
-                    .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                    .addHeader(CONTENT_TYPE, APPLICATION_JSON)
                     .body(jsonContent, UTF_8)
                     .build();
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/LoggingConfigurationHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/LoggingConfigurationHandler.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.admin.handlers;
 
-import com.google.common.net.MediaType;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
@@ -30,8 +29,7 @@ import java.util.function.Supplier;
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
-import static com.google.common.net.MediaType.XML_UTF_8;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -72,11 +70,11 @@ public class LoggingConfigurationHandler implements WebServiceHandler {
         try {
             String fileContents = Resources.load(logConfigLocation);
 
-            return new Content(XML_UTF_8, fileContents);
+            return new Content("text/xml; charset=utf-8", fileContents);
         } catch (IOException e) {
             logException(e);
 
-            return new Content(PLAIN_TEXT_UTF_8, "Could not load resource='" + logConfigLocation + "'");
+            return new Content(PLAIN_TEXT, "Could not load resource='" + logConfigLocation + "'");
         }
     }
 
@@ -89,10 +87,10 @@ public class LoggingConfigurationHandler implements WebServiceHandler {
         private final String type;
         private final int length;
 
-        Content(MediaType type, String content) {
+        Content(CharSequence type, String content) {
             this.content = content;
             this.type = type.toString();
-            this.length = content.getBytes(type.charset().get()).length;
+            this.length = content.getBytes(UTF_8).length;
         }
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/OriginsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/OriginsHandler.java
@@ -26,8 +26,8 @@ import com.hotels.styx.api.extension.service.spi.Registry;
 import com.hotels.styx.common.http.handler.BaseHttpHandler;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import static com.google.common.net.MediaType.JSON_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.APPLICATION_JSON;
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
@@ -59,7 +59,7 @@ public class OriginsHandler extends BaseHttpHandler {
             String jsonContent = marshal(object, prettyPrint);
             return response(OK)
                     .disableCaching()
-                    .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                    .addHeader(CONTENT_TYPE, "application/json")
                     .body(jsonContent, UTF_8)
                     .build();
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/OriginsInventoryHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/OriginsInventoryHandler.java
@@ -34,9 +34,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS;
-import static com.google.common.net.MediaType.JSON_UTF_8;
 import static com.hotels.styx.admin.support.Json.PRETTY_PRINTER;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.APPLICATION_JSON;
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.infrastructure.configuration.json.ObjectMappers.addStyxMixins;
@@ -67,7 +67,7 @@ public class OriginsInventoryHandler extends BaseHttpHandler implements OriginsC
     @Override
     protected HttpResponse doHandle(HttpRequest request, HttpInterceptor.Context context) {
         return response(OK)
-                .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                .addHeader(CONTENT_TYPE, APPLICATION_JSON)
                 .disableCaching()
                 .body(content(isPrettyPrint(request)), UTF_8)
                 .build();

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/PingHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/PingHandler.java
@@ -20,8 +20,8 @@ import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.common.http.handler.BaseHttpHandler;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -35,7 +35,7 @@ public class PingHandler extends BaseHttpHandler {
     protected HttpResponse doHandle(HttpRequest request, HttpInterceptor.Context context) {
         return response(OK)
                 .disableCaching()
-                .addHeader(CONTENT_TYPE, PLAIN_TEXT_UTF_8.toString())
+                .addHeader(CONTENT_TYPE, PLAIN_TEXT)
                 .body("pong", UTF_8)
                 .build();
     }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/PluginListHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/PluginListHandler.java
@@ -25,8 +25,8 @@ import com.hotels.styx.proxy.plugin.NamedPlugin;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static com.google.common.net.MediaType.HTML_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.HTML;
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static java.lang.String.format;
@@ -55,7 +55,7 @@ public class PluginListHandler implements WebServiceHandler {
 
         return Eventual.of(response(OK)
                 .body(output, UTF_8)
-                .addHeader(CONTENT_TYPE, HTML_UTF_8.toString())
+                .addHeader(CONTENT_TYPE, HTML)
                 .build());
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/PluginToggleHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/PluginToggleHandler.java
@@ -32,8 +32,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.api.HttpMethod.GET;
 import static com.hotels.styx.api.HttpMethod.PUT;
 import static com.hotels.styx.api.HttpResponse.response;
@@ -152,7 +152,7 @@ public class PluginToggleHandler implements WebServiceHandler {
     private static HttpResponse responseWith(HttpResponseStatus status, String message) {
         return HttpResponse.response(status)
                 .body(message + "\n", UTF_8)
-                .addHeader(CONTENT_TYPE, PLAIN_TEXT_UTF_8.toString())
+                .addHeader(CONTENT_TYPE, PLAIN_TEXT)
                 .disableCaching()
                 .build();
     }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/PrometheusHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/PrometheusHandler.java
@@ -22,8 +22,8 @@ import com.hotels.styx.api.HttpResponse;
 import com.hotels.styx.api.WebServiceHandler;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -40,7 +40,7 @@ public class PrometheusHandler implements WebServiceHandler {
         return Eventual.of(HttpResponse
                 .response(OK)
                 .disableCaching()
-                .header(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                .header(CONTENT_TYPE, PLAIN_TEXT)
                 .body(prometheusRegistry.scrape(), UTF_8, true)
                 .build());
     }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderListHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ProviderListHandler.java
@@ -25,10 +25,10 @@ import com.hotels.styx.api.WebServiceHandler;
 import com.hotels.styx.api.configuration.ObjectStore;
 import com.hotels.styx.api.extension.service.spi.StyxService;
 
-import static com.google.common.net.MediaType.HTML_UTF_8;
 import static com.hotels.styx.admin.AdminServerBuilder.adminEndpointPath;
 import static com.hotels.styx.admin.AdminServerBuilder.adminPath;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.HTML;
 import static com.hotels.styx.api.HttpResponse.response;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -72,7 +72,7 @@ public class ProviderListHandler implements WebServiceHandler {
         String html = String.format(HTML_TEMPLATE, TITLE, h2(TITLE) + providerList);
         return Eventual.of(response(OK)
                 .body(html, UTF_8)
-                .addHeader(CONTENT_TYPE, HTML_UTF_8.toString())
+                .addHeader(CONTENT_TYPE, HTML)
                 .build());
     }
 

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/StartupConfigHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/StartupConfigHandler.java
@@ -20,7 +20,7 @@ import com.hotels.styx.common.http.handler.StaticBodyHttpHandler;
 
 import java.util.stream.Stream;
 
-import static com.google.common.net.MediaType.HTML_UTF_8;
+import static com.hotels.styx.api.HttpHeaderValues.HTML;
 import static java.util.stream.Collectors.joining;
 
 /**
@@ -33,7 +33,7 @@ public class StartupConfigHandler extends StaticBodyHttpHandler {
      * @param startupConfig Styx Configuration
      */
     public StartupConfigHandler(StartupConfig startupConfig) {
-        super(HTML_UTF_8, render(startupConfig));
+        super(HTML, render(startupConfig));
     }
 
     private static String render(StartupConfig startupConfig) {

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/StyxConfigurationHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/StyxConfigurationHandler.java
@@ -26,8 +26,8 @@ import com.hotels.styx.common.http.handler.StaticBodyHttpHandler;
 
 import java.util.Map;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.hotels.styx.admin.support.Json.PRETTY_PRINTER;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 
 /**
  * Returns a response consisting of the configuration variables.
@@ -44,8 +44,8 @@ public class StyxConfigurationHandler implements WebServiceHandler {
      * @param configuration configuration
      */
     public StyxConfigurationHandler(Configuration configuration) {
-            styxConfigHandler = new StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, body(configuration));
-            prettyStyxConfigHandler = new StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, prettify(configuration));
+            styxConfigHandler = new StaticBodyHttpHandler(PLAIN_TEXT, body(configuration));
+            prettyStyxConfigHandler = new StaticBodyHttpHandler(PLAIN_TEXT, prettify(configuration));
     }
 
     @Override

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ThreadsHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/ThreadsHandler.java
@@ -27,8 +27,8 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 
 /**
@@ -40,7 +40,7 @@ public class ThreadsHandler extends BaseHttpHandler {
     public HttpResponse doHandle(HttpRequest request, HttpInterceptor.Context context) {
         return HttpResponse.response(OK)
                 .disableCaching()
-                .header(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                .header(CONTENT_TYPE, PLAIN_TEXT)
                 .body(threadDumpContent(), true)
                 .build();
     }

--- a/components/proxy/src/main/java/com/hotels/styx/admin/handlers/VersionTextHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/handlers/VersionTextHandler.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Optional;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.common.Preconditions.checkArgument;
 import static com.hotels.styx.javaconvenience.UtilKt.isEmpty;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -42,7 +42,7 @@ public class VersionTextHandler extends StaticBodyHttpHandler {
      * @param files content resources
      */
     public VersionTextHandler(Iterable<Resource> files) {
-        super(PLAIN_TEXT_UTF_8, body(files));
+        super(PLAIN_TEXT, body(files));
     }
 
     private static String body(Iterable<Resource> files) {

--- a/components/proxy/src/main/java/com/hotels/styx/admin/tasks/OriginsReloadCommandHandler.java
+++ b/components/proxy/src/main/java/com/hotels/styx/admin/tasks/OriginsReloadCommandHandler.java
@@ -31,8 +31,8 @@ import reactor.core.scheduler.Schedulers;
 
 import java.util.concurrent.ExecutorService;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.api.HttpResponseStatus.BAD_REQUEST;
 import static com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
@@ -96,7 +96,7 @@ public class OriginsReloadCommandHandler implements WebServiceHandler {
 
     private HttpResponse okResponse(String content) {
         return HttpResponse.response(OK)
-                .header(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                .header(CONTENT_TYPE, PLAIN_TEXT)
                 .body(content, UTF_8)
                 .build();
     }
@@ -128,7 +128,7 @@ public class OriginsReloadCommandHandler implements WebServiceHandler {
 
     private HttpResponse errorResponse(HttpResponseStatus code, String content) {
         return HttpResponse.response(code)
-                .header(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                .header(CONTENT_TYPE, PLAIN_TEXT)
                 .body(content, UTF_8)
                 .build();
     }

--- a/components/proxy/src/main/java/com/hotels/styx/startup/extensions/DemoPlugin.java
+++ b/components/proxy/src/main/java/com/hotels/styx/startup/extensions/DemoPlugin.java
@@ -29,8 +29,8 @@ import org.slf4j.Logger;
 
 import java.util.Map;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -77,7 +77,7 @@ public class DemoPlugin implements Plugin {
             LOGGER.info("Demo plugin serving admin page");
 
             return Eventual.of(
-                    HttpResponse.response().header(CONTENT_TYPE, PLAIN_TEXT_UTF_8)
+                    HttpResponse.response().header(CONTENT_TYPE, PLAIN_TEXT)
                             .body("This is an admin page provided by a demo plugin used to test Styx's plugin functionality. Text from config=" + config.adminText, UTF_8)
                             .build()
                             .stream());

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsAdminHandler.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsAdminHandler.kt
@@ -16,7 +16,6 @@
 package com.hotels.styx.services
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.common.net.MediaType.JSON_UTF_8
 import com.hotels.styx.*
 import com.hotels.styx.ErrorResponse
 import com.hotels.styx.admin.handlers.UrlPatternRouter
@@ -31,6 +30,7 @@ import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.Builtins.HEALTH_CHECK_MONITOR
 import com.hotels.styx.routing.db.StyxObjectStore
 import com.hotels.styx.ProviderObjectRecord
+import com.hotels.styx.api.HttpHeaderValues.APPLICATION_JSON
 import java.nio.charset.StandardCharsets.UTF_8
 
 /**
@@ -148,14 +148,14 @@ internal class OriginsAdminHandler(
     private fun errorResponse(status: HttpResponseStatus, message: String) =
             response(status)
                     .disableCaching()
-                    .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                    .addHeader(CONTENT_TYPE, APPLICATION_JSON)
                     .body(MAPPER.writeValueAsString(ErrorResponse(message)), UTF_8)
                     .build()
 
     private fun textValueResponse(message: String) =
             response(OK)
                     .disableCaching()
-                    .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                    .addHeader(CONTENT_TYPE, APPLICATION_JSON)
                     .body(MAPPER.writeValueAsString(message), UTF_8)
                     .build()
 

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/YamlFileConfigurationService.kt
@@ -16,24 +16,20 @@
 package com.hotels.styx.services
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.google.common.net.MediaType.HTML_UTF_8
-import com.google.common.net.MediaType.PLAIN_TEXT_UTF_8
-import com.hotels.styx.NettyExecutor
-import com.hotels.styx.common.http.handler.HttpContentHandler
+import com.hotels.styx.ProviderObjectRecord
+import com.hotels.styx.StyxObjectRecord
+import com.hotels.styx.api.HttpHeaderValues.HTML
+import com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT
 import com.hotels.styx.api.extension.service.spi.StyxService
 import com.hotels.styx.common.http.handler.HttpAggregator
+import com.hotels.styx.common.http.handler.HttpContentHandler
 import com.hotels.styx.config.schema.SchemaDsl
-import com.hotels.styx.config.schema.SchemaDsl.bool
-import com.hotels.styx.config.schema.SchemaDsl.field
-import com.hotels.styx.config.schema.SchemaDsl.optional
-import com.hotels.styx.config.schema.SchemaDsl.string
+import com.hotels.styx.config.schema.SchemaDsl.*
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig
 import com.hotels.styx.routing.RoutingObjectRecord
 import com.hotels.styx.routing.config.RoutingObjectFactory
 import com.hotels.styx.routing.config.StyxObjectDefinition
 import com.hotels.styx.routing.db.StyxObjectStore
-import com.hotels.styx.ProviderObjectRecord
-import com.hotels.styx.StyxObjectRecord
 import com.hotels.styx.server.handlers.ClassPathResourceHandler
 import com.hotels.styx.serviceproviders.ServiceProviderFactory
 import com.hotels.styx.services.OriginsConfigConverter.Companion.deserialiseOrigins
@@ -41,8 +37,6 @@ import com.hotels.styx.sourceTag
 import org.slf4j.LoggerFactory
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.lang.IllegalArgumentException
-import java.lang.RuntimeException
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
@@ -102,8 +96,8 @@ internal class YamlFileConfigurationService(
 
     override fun adminInterfaceHandlers(namespace: String) = mapOf(
             "assets/.*" to HttpAggregator(ClassPathResourceHandler("$namespace/assets/", "/admin/assets/YamlConfigurationService")),
-            "configuration" to HttpContentHandler(PLAIN_TEXT_UTF_8.toString(), UTF_8) { originsConfig },
-            "origins" to HttpContentHandler(HTML_UTF_8.toString(), UTF_8) {
+            "configuration" to HttpContentHandler(PLAIN_TEXT, UTF_8) { originsConfig },
+            "origins" to HttpContentHandler(HTML.toString(), UTF_8) {
                 OriginsPageRenderer("$namespace/assets", name, routeDb).render()
             },
             "/" to OriginsAdminHandler(namespace, name, routeDb, serviceDb))

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/IndexHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/IndexHandlerTest.java
@@ -35,7 +35,7 @@ public class IndexHandlerTest {
     public void printsTheRegisteredPaths() {
         HttpResponse response = Mono.from(handler.handle(get("/admin").build(), requestContext())).block();
         assertThat(response.status(), is(OK));
-        assertThat(response.contentType().get(), is("text/html; charset=utf-8"));
+        assertThat(response.contentType().map(String::toLowerCase).get(), is("text/html; charset=utf-8"));
         assertThat(response.bodyAs(UTF_8), is(
                 "<html><body><ol style='list-style-type: none; padding-left: 0px; margin-left: 0px;'>" +
                         "<li><a href='/admin/foo'>Abc</a></li>" +

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/MetricsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/MetricsHandlerTest.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 
-import static com.google.common.net.MediaType.JSON_UTF_8;
+import static com.hotels.styx.api.HttpHeaderValues.APPLICATION_JSON;
 import static com.hotels.styx.support.Support.requestContext;
 import static com.hotels.styx.api.HttpRequest.get;
 import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
@@ -50,7 +50,7 @@ public class MetricsHandlerTest {
     public void respondsToRequestWithJsonResponse() {
         HttpResponse response = Mono.from(handler.handle(get("/admin/metrics").build(), requestContext())).block();
         assertThat(response.status(), is(OK));
-        assertThat(response.contentType().get(), is(JSON_UTF_8.toString()));
+        assertThat(response.contentType().get(), is(APPLICATION_JSON.toString()));
     }
 
     @Disabled

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/OriginsHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/OriginsHandlerTest.java
@@ -28,7 +28,6 @@ import reactor.core.publisher.Mono;
 import java.io.IOException;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-import static com.google.common.net.MediaType.JSON_UTF_8;
 import static com.hotels.styx.support.Support.requestContext;
 import static com.hotels.styx.api.HttpRequest.get;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
@@ -38,6 +37,7 @@ import static com.hotels.styx.common.StyxFutures.await;
 import static com.hotels.styx.infrastructure.configuration.json.ObjectMappers.addStyxMixins;
 import static com.hotels.styx.support.ResourcePaths.fixturesHome;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
+import static io.netty.handler.codec.http.HttpHeaders.Values.APPLICATION_JSON;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -57,7 +57,7 @@ public class OriginsHandlerTest {
             HttpResponse response = Mono.from(handler.handle(get("/admin/configuration/origins").build(), requestContext())).block();
 
             assertThat(response.status(), is(OK));
-            assertThat(response.contentType(), isValue(JSON_UTF_8.toString()));
+            assertThat(response.contentType(), isValue(APPLICATION_JSON));
 
             Iterable<BackendService> result = newBackendServices(unmarshalApplications(response.bodyAs(UTF_8)));
 
@@ -73,7 +73,7 @@ public class OriginsHandlerTest {
         HttpResponse response = Mono.from(handler.handle(get("/admin/configuration/origins").build(), requestContext())).block();
 
         assertThat(response.status(), is(OK));
-        assertThat(response.contentType(), isValue(JSON_UTF_8.toString()));
+        assertThat(response.contentType(), isValue(APPLICATION_JSON));
 
         assertThat(response.bodyAs(UTF_8), is("[]"));
     }
@@ -88,7 +88,7 @@ public class OriginsHandlerTest {
             HttpResponse response = Mono.from(handler.handle(get("/admin/configuration/origins").build(), requestContext())).block();
 
             assertThat(response.status(), is(OK));
-            assertThat(response.contentType(), isValue(JSON_UTF_8.toString()));
+            assertThat(response.contentType(), isValue(APPLICATION_JSON));
 
             String body = response.bodyAs(UTF_8);
 

--- a/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ProviderListHandlerTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/admin/handlers/ProviderListHandlerTest.java
@@ -32,10 +32,10 @@ import reactor.core.publisher.Mono;
 import java.util.HashSet;
 import java.util.Map;
 
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
-import static com.hotels.styx.support.Support.requestContext;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.api.HttpRequest.get;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static com.hotels.styx.support.Support.requestContext;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -84,9 +84,9 @@ public class ProviderListHandlerTest {
         @Override
         public Map<String, HttpHandler> adminInterfaceHandlers(String namespace) {
             return ImmutableMap.of(
-                    "withslash/", new HttpContentHandler(PLAIN_TEXT_UTF_8.toString(), UTF_8, () -> "with slash"),
-                    "noslash", new HttpContentHandler(PLAIN_TEXT_UTF_8.toString(), UTF_8, () -> "no slash"),
-                    "/", new HttpContentHandler(PLAIN_TEXT_UTF_8.toString(), UTF_8, () -> "just a slash"));
+                    "withslash/", new HttpContentHandler(PLAIN_TEXT, UTF_8, () -> "with slash"),
+                    "noslash", new HttpContentHandler(PLAIN_TEXT, UTF_8, () -> "no slash"),
+                    "/", new HttpContentHandler(PLAIN_TEXT, UTF_8, () -> "just a slash"));
         }
     }
 }

--- a/components/server/src/main/java/com/hotels/styx/server/handlers/MediaTypes.java
+++ b/components/server/src/main/java/com/hotels/styx/server/handlers/MediaTypes.java
@@ -15,67 +15,55 @@
  */
 package com.hotels.styx.server.handlers;
 
-import com.google.common.net.MediaType;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.net.MediaType.CSS_UTF_8;
-import static com.google.common.net.MediaType.GIF;
-import static com.google.common.net.MediaType.HTML_UTF_8;
-import static com.google.common.net.MediaType.JAVASCRIPT_UTF_8;
-import static com.google.common.net.MediaType.JPEG;
-import static com.google.common.net.MediaType.MICROSOFT_EXCEL;
-import static com.google.common.net.MediaType.MPEG_AUDIO;
-import static com.google.common.net.MediaType.MPEG_VIDEO;
-import static com.google.common.net.MediaType.OCTET_STREAM;
-import static com.google.common.net.MediaType.PDF;
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
-import static com.google.common.net.MediaType.PNG;
-import static com.google.common.net.MediaType.create;
+import static com.hotels.styx.api.HttpHeaderValues.APPLICATION_JSON;
+import static com.hotels.styx.api.HttpHeaderValues.HTML;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 
 /**
- * A collection of {@link MediaType}s associated with file extensions.
+ * A collection of media types associated with file extensions.
  */
 final class MediaTypes {
     private MediaTypes() {
     }
 
-    public static final MediaType MICROSOFT_MS_VIDEO = create("video", "x-msvideo");
-    public static final MediaType MICROSOFT_ASF_VIDEO = create("video", "x-ms-asf");
+    public static final CharSequence MICROSOFT_MS_VIDEO = "video/x-msvideo";
+    public static final CharSequence MICROSOFT_ASF_VIDEO = "video/x-ms-asf";
 
-    public static final MediaType WAV_AUDIO = create("audio", "x-wav");
-    public static final MediaType ICON = create("image", "x-icon");
-    public static final MediaType EVENT_STREAM = create("text", "event-stream");
+    public static final CharSequence WAV_AUDIO = "audio/x-wav";
+    public static final CharSequence ICON = "image/x-icon";
 
-    private static final Map<String, MediaType> MEDIA_TYPES_BY_EXTENSION = new HashMap<>();
+    public static final CharSequence OCTET_STREAM = "application/octet-stream";
+    private static final Map<String, CharSequence> MEDIA_TYPES_BY_EXTENSION = new HashMap<>();
 
-    private static void addMediaType(MediaType mediaType, String... extensions) {
+    private static void addMediaType(CharSequence mediaType, String... extensions) {
         for (String extension : extensions) {
             MEDIA_TYPES_BY_EXTENSION.put(extension, mediaType);
         }
     }
 
     static {
-        addMediaType(PLAIN_TEXT_UTF_8, "txt");
-        addMediaType(HTML_UTF_8, "html", "htm");
-        addMediaType(CSS_UTF_8, "css");
-        addMediaType(JAVASCRIPT_UTF_8, "js");
+        addMediaType(PLAIN_TEXT, "txt");
+        addMediaType(HTML, "html", "htm");
+        addMediaType("text/css;charset=UTF-8", "css");
+        addMediaType(APPLICATION_JSON, "js");
 
         addMediaType(ICON, "ico");
-        addMediaType(GIF, "gif");
-        addMediaType(JPEG, "jpg", "jpeg");
-        addMediaType(PNG, "png");
-        addMediaType(MICROSOFT_EXCEL, "xls");
-        addMediaType(PDF, "pdf");
+        addMediaType("image/gif", "gif");
+        addMediaType("image/jpeg", "jpg", "jpeg");
+        addMediaType("image/png", "png");
+        addMediaType("application/vnd.ms-excel", "xls");
+        addMediaType("application/pdf", "pdf");
 
-        addMediaType(MPEG_AUDIO, "mp3");
+        addMediaType("audio/mpeg", "mp3");
         addMediaType(WAV_AUDIO, "wav");
 
         addMediaType(MICROSOFT_ASF_VIDEO, "asf");
         addMediaType(MICROSOFT_MS_VIDEO, "avi");
-        addMediaType(MPEG_VIDEO, "mpg");
+        addMediaType("video/mpeg", "mpg");
     }
 
     /**
@@ -85,7 +73,7 @@ final class MediaTypes {
      * @param extension the file extension
      * @return the mime type of the given file extension
      */
-    public static MediaType mediaTypeForExtension(String extension) {
+    public static CharSequence mediaTypeForExtension(String extension) {
         return Optional.ofNullable(MEDIA_TYPES_BY_EXTENSION.get(extension))
                 .orElse(OCTET_STREAM);
     }
@@ -96,7 +84,7 @@ final class MediaTypes {
      *
      * @return the mime type of the given filename based on the file extension
      */
-    public static MediaType mediaTypeOf(String filename) {
+    public static CharSequence mediaTypeOf(String filename) {
         int dotPosition = filename.lastIndexOf('.');
         if (dotPosition > 0) {
             return mediaTypeForExtension(filename.substring(dotPosition + 1));

--- a/components/server/src/main/java/com/hotels/styx/server/handlers/StaticFileHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/handlers/StaticFileHandler.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.server.handlers;
 
 import com.google.common.io.Files;
-import com.google.common.net.MediaType;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
@@ -72,7 +71,7 @@ public class StaticFileHandler implements HttpHandler {
 
     private static class ResolvedFile {
         private final String content;
-        private final MediaType mediaType;
+        private final CharSequence mediaType;
 
         private ResolvedFile(File file) {
             this.content = readLines(file);

--- a/components/server/src/test/java/com/hotels/styx/server/handlers/MediaTypesTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/handlers/MediaTypesTest.java
@@ -15,63 +15,52 @@
  */
 package com.hotels.styx.server.handlers;
 
-import com.google.common.net.MediaType;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import static com.google.common.net.MediaType.CSS_UTF_8;
-import static com.google.common.net.MediaType.GIF;
-import static com.google.common.net.MediaType.HTML_UTF_8;
-import static com.google.common.net.MediaType.JAVASCRIPT_UTF_8;
-import static com.google.common.net.MediaType.JPEG;
-import static com.google.common.net.MediaType.MICROSOFT_EXCEL;
-import static com.google.common.net.MediaType.MPEG_AUDIO;
-import static com.google.common.net.MediaType.MPEG_VIDEO;
-import static com.google.common.net.MediaType.OCTET_STREAM;
-import static com.google.common.net.MediaType.PDF;
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
-import static com.google.common.net.MediaType.PNG;
+import static com.hotels.styx.api.HttpHeaderValues.APPLICATION_JSON;
+import static com.hotels.styx.api.HttpHeaderValues.HTML;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.server.handlers.MediaTypes.ICON;
 import static com.hotels.styx.server.handlers.MediaTypes.MICROSOFT_ASF_VIDEO;
 import static com.hotels.styx.server.handlers.MediaTypes.MICROSOFT_MS_VIDEO;
+import static com.hotels.styx.server.handlers.MediaTypes.OCTET_STREAM;
 import static com.hotels.styx.server.handlers.MediaTypes.WAV_AUDIO;
 import static com.hotels.styx.server.handlers.MediaTypes.mediaTypeForExtension;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 public class MediaTypesTest {
-
     @ParameterizedTest
     @MethodSource("mediaTypesByFileExtensions")
-    public void returnsMediaTypesByFileExtensions(String extension, MediaType mediaType) {
+    public void returnsMediaTypesByFileExtensions(String extension, CharSequence mediaType) {
         assertThat(mediaTypeForExtension(extension), is(mediaType));
     }
 
-
     private static Stream<Arguments> mediaTypesByFileExtensions() {
         return Stream.of(
-                Arguments.of("htm", HTML_UTF_8),
-                Arguments.of("txt", PLAIN_TEXT_UTF_8),
+                Arguments.of("htm", HTML),
+                Arguments.of("txt", PLAIN_TEXT),
                 Arguments.of("unknown", OCTET_STREAM),
-                Arguments.of("css", CSS_UTF_8),
-                Arguments.of("js", JAVASCRIPT_UTF_8),
+                Arguments.of("css", "text/css;charset=UTF-8"),
+                Arguments.of("js", APPLICATION_JSON),
                 Arguments.of("ico", ICON),
-                Arguments.of("gif", GIF),
-                Arguments.of("jpg", JPEG),
-                Arguments.of("jpeg", JPEG),
-                Arguments.of("png", PNG),
-                Arguments.of("xls", MICROSOFT_EXCEL),
-                Arguments.of("pdf", PDF),
+                Arguments.of("gif", "image/gif"),
+                Arguments.of("jpg", "image/jpeg"),
+                Arguments.of("jpeg", "image/jpeg"),
+                Arguments.of("png", "image/png"),
+                Arguments.of("xls", "application/vnd.ms-excel"),
+                Arguments.of("pdf", "application/pdf"),
 
-                Arguments.of("mp3", MPEG_AUDIO),
+                Arguments.of("mp3", "audio/mpeg"),
                 Arguments.of("wav", WAV_AUDIO),
 
                 Arguments.of("asf", MICROSOFT_ASF_VIDEO),
                 Arguments.of("avi", MICROSOFT_MS_VIDEO),
-                Arguments.of("mpg", MPEG_VIDEO)
+                Arguments.of("mpg", "video/mpeg")
         );
     }
 }

--- a/components/server/src/test/java/com/hotels/styx/server/handlers/StaticFileHandlerTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/handlers/StaticFileHandlerTest.java
@@ -16,7 +16,6 @@
 package com.hotels.styx.server.handlers;
 
 import com.google.common.io.Files;
-import com.google.common.net.MediaType;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import org.junit.jupiter.api.AfterEach;
@@ -32,26 +31,18 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static com.google.common.net.MediaType.CSS_UTF_8;
-import static com.google.common.net.MediaType.GIF;
-import static com.google.common.net.MediaType.HTML_UTF_8;
-import static com.google.common.net.MediaType.JAVASCRIPT_UTF_8;
-import static com.google.common.net.MediaType.JPEG;
-import static com.google.common.net.MediaType.MICROSOFT_EXCEL;
-import static com.google.common.net.MediaType.MPEG_AUDIO;
-import static com.google.common.net.MediaType.MPEG_VIDEO;
-import static com.google.common.net.MediaType.OCTET_STREAM;
-import static com.google.common.net.MediaType.PDF;
-import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
-import static com.google.common.net.MediaType.PNG;
+import static com.hotels.styx.api.HttpHeaderValues.APPLICATION_JSON;
+import static com.hotels.styx.api.HttpHeaderValues.HTML;
+import static com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT;
 import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static com.hotels.styx.api.LiveHttpRequest.get;
-import static com.hotels.styx.support.Support.requestContext;
 import static com.hotels.styx.server.handlers.MediaTypes.ICON;
 import static com.hotels.styx.server.handlers.MediaTypes.MICROSOFT_ASF_VIDEO;
 import static com.hotels.styx.server.handlers.MediaTypes.MICROSOFT_MS_VIDEO;
+import static com.hotels.styx.server.handlers.MediaTypes.OCTET_STREAM;
 import static com.hotels.styx.server.handlers.MediaTypes.WAV_AUDIO;
+import static com.hotels.styx.support.Support.requestContext;
 import static com.hotels.styx.support.api.matchers.HttpStatusMatcher.hasStatus;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -137,7 +128,7 @@ public class StaticFileHandlerTest {
 
     @ParameterizedTest
     @MethodSource("fileTypesProvider")
-    public void setsTheContentTypeBasedOnFileExtension(String path, MediaType mediaType) throws Exception {
+    public void setsTheContentTypeBasedOnFileExtension(String path, CharSequence mediaType) throws Exception {
         writeFile(path, mediaType.toString());
 
         handler = new StaticFileHandler(dir);
@@ -149,24 +140,24 @@ public class StaticFileHandlerTest {
 
     private static Stream<Arguments> fileTypesProvider() {
         return Stream.of(
-                Arguments.of("foo.html", HTML_UTF_8),
-                Arguments.of("foo.gif", GIF),
-                Arguments.of("foo.jpg", JPEG),
-                Arguments.of("foo.png", PNG),
-                Arguments.of("foo.css", CSS_UTF_8),
+                Arguments.of("foo.html", HTML),
+                Arguments.of("foo.gif", "image/gif"),
+                Arguments.of("foo.jpg", "image/jpeg"),
+                Arguments.of("foo.png", "image/png"),
+                Arguments.of("foo.css", "text/css;charset=UTF-8"),
                 Arguments.of("foo.ico", ICON),
-                Arguments.of("foo.js", JAVASCRIPT_UTF_8),
-                Arguments.of("foo.xls", MICROSOFT_EXCEL),
-                Arguments.of("foo.txt", PLAIN_TEXT_UTF_8),
+                Arguments.of("foo.js", APPLICATION_JSON),
+                Arguments.of("foo.xls", "application/vnd.ms-excel"),
+                Arguments.of("foo.txt", PLAIN_TEXT),
                 Arguments.of("foo.pgp", OCTET_STREAM),
-                Arguments.of("foo.pdf", PDF),
+                Arguments.of("foo.pdf", "application/pdf"),
 
-                Arguments.of("foo.mp3", MPEG_AUDIO),
+                Arguments.of("foo.mp3", "audio/mpeg"),
                 Arguments.of("foo.wav", WAV_AUDIO),
 
                 Arguments.of("foo.asf", MICROSOFT_ASF_VIDEO),
                 Arguments.of("foo.avi", MICROSOFT_MS_VIDEO),
-                Arguments.of("foo.mpg", MPEG_VIDEO)
+                Arguments.of("foo.mpg", "video/mpeg")
         );
     }
 

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/handlers/ContentDigestHandler.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/handlers/ContentDigestHandler.java
@@ -23,7 +23,7 @@ import com.hotels.styx.common.http.handler.BaseHttpHandler;
 
 import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
-import static com.google.common.net.MediaType.HTML_UTF_8;
+import static com.hotels.styx.api.HttpHeaderValues.HTML;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -45,7 +45,7 @@ public class ContentDigestHandler extends BaseHttpHandler {
                 request.bodyAs(UTF_8).hashCode());
 
         return HttpResponse.response(OK)
-                .header(CONTENT_TYPE, HTML_UTF_8.toString())
+                .header(CONTENT_TYPE, HTML)
                 .header(CONTENT_LENGTH, responseBody.getBytes(UTF_8).length)
                 .body(responseBody, UTF_8)
                 .build();

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/PluginAdminInterfaceSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/admin/PluginAdminInterfaceSpec.kt
@@ -15,8 +15,8 @@
  */
 package com.hotels.styx.admin
 
-import com.google.common.net.MediaType.PLAIN_TEXT_UTF_8
 import com.hotels.styx.api.HttpHandler
+import com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT
 import com.hotels.styx.api.HttpInterceptor
 import com.hotels.styx.api.LiveHttpRequest
 import com.hotels.styx.api.plugins.spi.Plugin
@@ -121,8 +121,8 @@ private class PluginX : Plugin {
     override fun intercept(request: LiveHttpRequest, chain: HttpInterceptor.Chain) = chain.proceed(request)
 
     override fun adminInterfaceHandlers() = mapOf<String, HttpHandler>(
-            "/path/one" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, "X: Response from first admin interface")),
-            "/path/two" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, "X: Response from second admin interface"))
+            "/path/one" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT, "X: Response from first admin interface")),
+            "/path/two" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT, "X: Response from second admin interface"))
     )
 }
 
@@ -130,8 +130,8 @@ private class PluginY : Plugin {
     override fun intercept(request: LiveHttpRequest, chain: HttpInterceptor.Chain) = chain.proceed(request)
 
     override fun adminInterfaceHandlers() = mapOf<String, HttpHandler>(
-            "/path/one" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, "Y: Response from first admin interface")),
-            "/path/two" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, "Y: Response from second admin interface"))
+            "/path/one" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT, "Y: Response from first admin interface")),
+            "/path/two" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT, "Y: Response from second admin interface"))
     )
 }
 
@@ -139,8 +139,8 @@ private class PluginZ : Plugin {
     override fun intercept(request: LiveHttpRequest, chain: HttpInterceptor.Chain) = chain.proceed(request)
 
     override fun adminInterfaceHandlers() = mapOf<String, HttpHandler>(
-            "path/one" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, "Z: Response from first admin interface")),
-            "path/two" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT_UTF_8, "Z: Response from second admin interface"))
+            "path/one" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT, "Z: Response from first admin interface")),
+            "path/two" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT, "Z: Response from second admin interface"))
     )
 }
 

--- a/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/server/ServerStartupSpec.kt
+++ b/system-tests/ft-suite/src/test/kotlin/com/hotels/styx/server/ServerStartupSpec.kt
@@ -15,9 +15,9 @@
  */
 package com.hotels.styx.server
 
-import com.google.common.net.MediaType
 import com.hotels.styx.api.HttpHandler
 import com.hotels.styx.api.HttpHeaderNames.HOST
+import com.hotels.styx.api.HttpHeaderValues.PLAIN_TEXT
 import com.hotels.styx.api.HttpInterceptor
 import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.api.HttpResponseStatus.OK
@@ -101,7 +101,7 @@ private class SlowlyStartingPlugin(val barrier: CyclicBarrier, val latch2: Count
     }
 
     override fun adminInterfaceHandlers() = mapOf<String, HttpHandler>(
-            "/path/one" to HttpAggregator(StaticBodyHttpHandler(MediaType.PLAIN_TEXT_UTF_8, "X: Response from first admin interface")),
-            "/path/two" to HttpAggregator(StaticBodyHttpHandler(MediaType.PLAIN_TEXT_UTF_8, "X: Response from second admin interface"))
+            "/path/one" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT, "X: Response from first admin interface")),
+            "/path/two" to HttpAggregator(StaticBodyHttpHandler(PLAIN_TEXT, "X: Response from second admin interface"))
     )
 }


### PR DESCRIPTION
Removes uses of Guava's MediaType class. This was always getting converted to String before use, so it's not too difficult. Where possible, already declared constants from elsewhere are used instead.

This is a continuation of the Guava removal https://github.com/ExpediaGroup/styx/pull/755

> To reduce the need to continually update third-party dependencies for security vulnerabilities, we can remove dependencies we don't need. Reduced dependencies are also good for Styx, as it is a plugin framework and dependencies can clash with plugins.
> 
> Removing Guava entirely would be a very big PR, so this PR merely reduces it, targeting the use of Guava collections in particular. Future PRs will remove more.
> 
> Many of the Guava methods used are now replicated (or sufficiently approximated) by the Java standard library. Others are easy to implement ourselves, and a few were never needed to begin with.
> 
> These method calls have been replaced or removed.