### PR TITLE
Remove Guava Charsets

### DIFF
--- a/components/client/src/test/integration/scala/com/hotels/styx/client/BackendServiceClientSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/BackendServiceClientSpec.scala
@@ -15,18 +15,16 @@
  */
 package com.hotels.styx.client
 
-import java.util.concurrent.atomic.AtomicLong
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.google.common.base.Charsets._
 import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.LiveHttpRequest.get
-import com.hotels.styx.api.{LiveHttpResponse, MicrometerRegistry}
 import com.hotels.styx.api.exceptions.ResponseTimeoutException
 import com.hotels.styx.api.extension.Origin._
 import com.hotels.styx.api.extension.loadbalancing.spi.LoadBalancer
 import com.hotels.styx.api.extension.service.BackendService
 import com.hotels.styx.api.extension.{ActiveOrigins, Origin}
+import com.hotels.styx.api.{LiveHttpResponse, MicrometerRegistry}
 import com.hotels.styx.client.OriginsInventory.newOriginsInventoryBuilder
 import com.hotels.styx.client.StyxBackendServiceClient._
 import com.hotels.styx.client.loadbalancing.strategies.BusyConnectionsStrategy
@@ -47,6 +45,8 @@ import org.scalatest._
 import org.scalatest.mock.MockitoSugar
 import reactor.core.publisher.Mono
 
+import java.nio.charset.StandardCharsets._
+import java.util.concurrent.atomic.AtomicLong
 import scala.util.Try
 
 class BackendServiceClientSpec extends FunSuite with BeforeAndAfterAll with Matchers with BeforeAndAfter with MockitoSugar {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/OriginClosesConnectionSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/client/OriginClosesConnectionSpec.scala
@@ -16,7 +16,6 @@
 package com.hotels.styx.client
 
 import ch.qos.logback.classic.Level
-import com.google.common.base.Charsets._
 import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.api.HttpResponseStatus.OK
 import com.hotels.styx.api.exceptions.TransportException
@@ -47,6 +46,7 @@ import org.scalatest.concurrent.Eventually
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 
+import java.nio.charset.StandardCharsets._
 import scala.compat.java8.StreamConverters._
 import scala.concurrent.duration._
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BadFramingSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BadFramingSpec.scala
@@ -15,13 +15,8 @@
  */
 package com.hotels.styx.proxy
 
-import java.util.Optional
-import java.util.concurrent.TimeUnit.SECONDS
-
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.google.common.base.Charsets.UTF_8
 import com.google.common.net.HostAndPort._
-import com.hotels.styx.{DefaultStyxConfiguration, StyxProxySpec, api}
 import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.api.HttpResponseStatus.{BAD_REQUEST, OK}
 import com.hotels.styx.support.backends.FakeHttpServer
@@ -29,6 +24,7 @@ import com.hotels.styx.support.configuration.{HttpBackend, Origins}
 import com.hotels.styx.support.{NettyOrigins, TestClientSupport}
 import com.hotels.styx.utils.HttpTestClient
 import com.hotels.styx.utils.StubOriginHeader.STUB_ORIGIN_INFO
+import com.hotels.styx.{DefaultStyxConfiguration, StyxProxySpec, api}
 import io.netty.buffer.Unpooled.copiedBuffer
 import io.netty.channel._
 import io.netty.handler.codec.http.HttpHeaders.Names.{CONTENT_LENGTH, HOST, TRANSFER_ENCODING}
@@ -37,6 +33,10 @@ import io.netty.handler.codec.http.HttpMethod._
 import io.netty.handler.codec.http.HttpVersion.HTTP_1_1
 import io.netty.handler.codec.http._
 import org.scalatest.FunSpec
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Optional
+import java.util.concurrent.TimeUnit.SECONDS
 
 class BadFramingSpec extends FunSpec
   with StyxProxySpec

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BadRequestsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BadRequestsSpec.scala
@@ -15,10 +15,7 @@
  */
 package com.hotels.styx.proxy
 
-import java.util.concurrent.TimeUnit
-
 import ch.qos.logback.classic.Level.ERROR
-import com.google.common.base.Charsets.{US_ASCII, UTF_8}
 import com.google.common.net.HostAndPort
 import com.hotels.styx.StyxProxySpec
 import com.hotels.styx.api.HttpHeaderNames.{CONTENT_TYPE, HOST}
@@ -42,6 +39,8 @@ import org.hamcrest.Matchers.{hasItem, is}
 import org.scalatest.FunSpec
 import org.scalatest.concurrent.Eventually
 
+import java.nio.charset.StandardCharsets.{US_ASCII, UTF_8}
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 class BadRequestsSpec extends FunSpec
   with StyxProxySpec

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BadResponseFromOriginSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BadResponseFromOriginSpec.scala
@@ -15,9 +15,6 @@
  */
 package com.hotels.styx.proxy
 
-import java.util.Optional
-
-import com.google.common.base.Charsets.UTF_8
 import com.hotels.styx.api.HttpHeaderNames.CONNECTION
 import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.api.HttpResponseStatus.BAD_GATEWAY
@@ -41,6 +38,8 @@ import org.scalatest.FunSpec
 import org.scalatest.concurrent.Eventually
 import org.slf4j.LoggerFactory
 
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.Optional
 import scala.concurrent.duration._
 import scala.util.Random
 

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BigFileDownloadSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BigFileDownloadSpec.scala
@@ -15,10 +15,6 @@
  */
 package com.hotels.styx.proxy
 
-import java.io.{File, IOException, RandomAccessFile}
-import java.util.concurrent.TimeUnit.MILLISECONDS
-
-import com.google.common.base.Charsets.UTF_8
 import com.google.common.io.Files
 import com.google.common.io.Files._
 import com.hotels.styx.MockServer.responseSupplier
@@ -33,6 +29,9 @@ import org.scalatest.FunSpec
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 
+import java.io.{File, IOException, RandomAccessFile}
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import scala.concurrent.duration._
 
 class BigFileDownloadSpec extends FunSpec

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedDownloadSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedDownloadSpec.scala
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.proxy
 
-import com.google.common.base.Charsets
-import com.google.common.base.Charsets._
 import com.hotels.styx._
 import com.hotels.styx.api.HttpRequest.get
 import com.hotels.styx.api.HttpResponseStatus._
@@ -37,6 +35,7 @@ import io.netty.handler.codec.http._
 import org.scalatest.FunSpec
 import org.scalatest.concurrent.Eventually
 
+import java.nio.charset.StandardCharsets._
 import scala.concurrent.duration.{Duration, _}
 
 
@@ -175,7 +174,7 @@ class ChunkedDownloadSpec extends FunSpec
       ctx.writeAndFlush(EMPTY_LAST_CONTENT)
       return
     }
-    ctx.writeAndFlush(new DefaultHttpContent(Unpooled.copiedBuffer(chunkData, Charsets.UTF_8)))
+    ctx.writeAndFlush(new DefaultHttpContent(Unpooled.copiedBuffer(chunkData, UTF_8)))
     Thread.sleep(delay.toMillis)
     sendContentInChunks(ctx, data.drop(100), delay)
   }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedRequestSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedRequestSpec.scala
@@ -15,22 +15,22 @@
  */
 package com.hotels.styx.proxy
 
-import java.io.{ByteArrayInputStream, IOException, InputStream}
-import java.net.{HttpURLConnection, URL}
-
 import com.github.tomakehurst.wiremock.client.{RequestPatternBuilder, UrlMatchingStrategy, ValueMatchingStrategy}
 import com.github.tomakehurst.wiremock.http.RequestMethod
-import com.google.common.base.Charsets._
-import com.google.common.base.Strings._
 import com.google.common.base.Optional
+import com.google.common.base.Strings._
 import com.google.common.io.ByteStreams
 import com.google.common.io.ByteStreams._
-import com.hotels.styx.{DefaultStyxConfiguration, StyxProxySpec}
 import com.hotels.styx.api.{HttpResponse, HttpResponseStatus, LiveHttpResponse}
 import com.hotels.styx.support.TestClientSupport
 import com.hotels.styx.support.backends.FakeHttpServer
 import com.hotels.styx.support.configuration.{HttpBackend, Origins}
+import com.hotels.styx.{DefaultStyxConfiguration, StyxProxySpec}
 import org.scalatest.FunSpec
+
+import java.io.{ByteArrayInputStream, IOException, InputStream}
+import java.net.{HttpURLConnection, URL}
+import java.nio.charset.StandardCharsets._
 
 class ChunkedRequestSpec extends FunSpec
   with StyxProxySpec

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedUploadSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/ChunkedUploadSpec.scala
@@ -15,21 +15,13 @@
  */
 package com.hotels.styx.proxy
 
-import java.util.concurrent.TimeUnit.SECONDS
-
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.google.common.base.Charsets
-import com.google.common.base.Charsets._
 import com.google.common.net.HostAndPort
-import com.hotels.styx.api.extension.Origin.newOriginBuilder
-import com.hotels.styx.common.FreePorts._
-import com.hotels.styx.common.http.handler.HttpAggregator
-import com.hotels.styx.server.HttpServers.createHttpServer
 import com.hotels.styx.support.TestClientSupport
-import com.hotels.styx.support.configuration.{HttpBackend, Origins, ProxyConfig, StyxConfig}
 import com.hotels.styx.support.backends.FakeHttpServer
-import com.hotels.styx.utils.handlers.ContentDigestHandler
+import com.hotels.styx.support.configuration.{HttpBackend, Origins, ProxyConfig, StyxConfig}
+import com.hotels.styx.utils.HttpTestClient
 import com.hotels.styx.{StyxClientSupplier, StyxProxySpec}
 import io.netty.buffer.Unpooled
 import io.netty.buffer.Unpooled._
@@ -46,8 +38,9 @@ import org.scalatest.FunSpec
 import org.scalatest.concurrent.Eventually
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory._
-import com.hotels.styx.utils.HttpTestClient
 
+import java.nio.charset.StandardCharsets._
+import java.util.concurrent.TimeUnit.SECONDS
 import scala.concurrent.duration._
 
 class ChunkedUploadSpec extends FunSpec
@@ -300,12 +293,12 @@ class ChunkedUploadSpec extends FunSpec
     request
   }
 
-  def contentOf(response: FullHttpResponse) = response.content().toString(Charsets.UTF_8)
+  def contentOf(response: FullHttpResponse) = response.content().toString(UTF_8)
 
   def sendContentInChunks(client: HttpTestClient, data: String, delay: Duration): Unit = {
     val chunkData = data.take(100)
     if (chunkData.length > 0) {
-      client.write(new DefaultHttpContent(Unpooled.copiedBuffer(chunkData, Charsets.UTF_8)))
+      client.write(new DefaultHttpContent(Unpooled.copiedBuffer(chunkData, UTF_8)))
       Thread.sleep(delay.toMillis)
       sendContentInChunks(client, data.drop(100), delay)
     }

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/KeepAliveSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/KeepAliveSpec.scala
@@ -15,10 +15,7 @@
  */
 package com.hotels.styx.proxy
 
-import java.lang.Thread.sleep
-
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.google.common.base.Charsets.UTF_8
 import com.hotels.styx.StyxProxySpec
 import com.hotels.styx.support.TestClientSupport
 import com.hotels.styx.support.backends.FakeHttpServer
@@ -33,6 +30,8 @@ import io.netty.handler.codec.http._
 import org.scalatest.FunSpec
 import org.scalatest.concurrent.Eventually
 
+import java.lang.Thread.sleep
+import java.nio.charset.StandardCharsets.UTF_8
 import scala.concurrent.duration._
 
 class KeepAliveSpec extends FunSpec

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/BadCookiesSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/BadCookiesSpec.scala
@@ -15,16 +15,12 @@
  */
 package com.hotels.styx.proxy.resiliency
 
-import java.util.concurrent.TimeUnit._
-
-import com.google.common.base.Charsets._
-import com.hotels.styx.{DefaultStyxConfiguration, StyxProxySpec}
 import com.hotels.styx.generators.HttpRequestGenerator
 import com.hotels.styx.support.configuration.{HttpBackend, Origins}
 import com.hotels.styx.support.generators.{CookieHeaderGenerator, CookieHeaderString}
 import com.hotels.styx.support.{NettyOrigins, TestClientSupport}
 import com.hotels.styx.utils.HttpTestClient
-import io.netty.channel.ChannelHandlerContext
+import com.hotels.styx.{DefaultStyxConfiguration, StyxProxySpec}
 import io.netty.handler.codec.http.HttpHeaders.Names._
 import io.netty.handler.codec.http.HttpMethod._
 import io.netty.handler.codec.http.HttpResponseStatus._
@@ -36,6 +32,7 @@ import org.scalacheck.Test
 import org.scalatest.prop.{Checkers, Configuration}
 import org.scalatest.{BeforeAndAfter, FunSpec}
 
+import java.util.concurrent.TimeUnit._
 import scala.util.Try
 
 class BadCookiesSpec extends FunSpec

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/LongDownloadsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/LongDownloadsSpec.scala
@@ -15,13 +15,9 @@
  */
 package com.hotels.styx.proxy.resiliency
 
-import java.io.{File, IOException, RandomAccessFile}
-import java.net.URL
-
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
-import com.google.common.base.Charsets._
 import com.google.common.io.Files
 import com.hotels.styx.MockServer.responseSupplier
 import com.hotels.styx._
@@ -38,6 +34,9 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, Matchers, SequentialNestedSuiteExecution}
 import org.slf4j.LoggerFactory
 
+import java.io.{File, IOException, RandomAccessFile}
+import java.net.URL
+import java.nio.charset.StandardCharsets._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/ProxyResiliencySpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/ProxyResiliencySpec.scala
@@ -15,9 +15,6 @@
  */
 package com.hotels.styx.proxy.resiliency
 
-import java.util.concurrent.TimeUnit._
-
-import com.google.common.base.Charsets._
 import com.hotels.styx.StyxProxySpec
 import com.hotels.styx.generators.HttpRequestGenerator
 import com.hotels.styx.support.ResourcePaths.fixturesHome
@@ -32,6 +29,8 @@ import org.scalatest.prop.{Checkers, Configuration, PropertyChecks}
 import org.scalatest.{BeforeAndAfter, FunSpec}
 import org.slf4j.LoggerFactory
 
+import java.nio.charset.StandardCharsets._
+import java.util.concurrent.TimeUnit._
 import scala.util.{Failure, Success, Try}
 
 class ProxyResiliencySpec extends FunSpec


### PR DESCRIPTION
This is a continuation of the Guava removal https://github.com/ExpediaGroup/styx/pull/755

> To reduce the need to continually update third-party dependencies for security vulnerabilities, we can remove dependencies we don't need. Reduced dependencies are also good for Styx, as it is a plugin framework and dependencies can clash with plugins.
> 
> Removing Guava entirely would be a very big PR, so this PR merely reduces it, targeting the use of Guava collections in particular. Future PRs will remove more.
> 
> Many of the Guava methods used are now replicated (or sufficiently approximated) by the Java standard library. Others are easy to implement ourselves, and a few were never needed to begin with.
> 
> These method calls have been replaced or removed.