### PR TITLE
Remove Guava File IO

### DIFF
--- a/components/common/src/main/java/com/hotels/styx/common/io/FileResourceIterator.java
+++ b/components/common/src/main/java/com/hotels/styx/common/io/FileResourceIterator.java
@@ -18,12 +18,13 @@ package com.hotels.styx.common.io;
 import com.hotels.styx.api.Resource;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static com.google.common.io.Files.fileTraverser;
-import static java.util.stream.StreamSupport.stream;
+import static com.hotels.styx.javaconvenience.UtilKt.uncheck;
+import static java.nio.file.Files.walk;
 
 /**
  * Iterates over resources in a file system location.
@@ -32,9 +33,9 @@ public class FileResourceIterator implements Iterator<Resource> {
     private final Iterator<Resource> resourceIterator;
 
     public FileResourceIterator(File root, File file, String suffix) {
-        File absolutePath = root.toPath().resolve(file.toPath()).toFile();
-        Iterable<File> children = fileTraverser().depthFirstPostOrder(absolutePath);
-        this.resourceIterator = stream(children.spliterator(), false)
+        Path absolutePath = root.toPath().resolve(file.toPath());
+        this.resourceIterator = uncheck(() -> walk(absolutePath))
+                .map(Path::toFile)
                 .filter(hasSuffix(suffix).or(sameFile(file)))
                 .map(fileToResource(file))
                 .iterator();

--- a/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
+++ b/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
@@ -15,6 +15,10 @@
  */
 package com.hotels.styx.javaconvenience
 
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.Callable
+import java.util.function.Supplier
 import java.util.stream.Stream
 import kotlin.streams.asStream
 
@@ -71,6 +75,12 @@ fun <K, V> orderedMap(vararg entries: com.hotels.styx.common.Pair<K, V>): Map<K,
 
     return map
 }
+
+/**
+ * Allows Java checked exception to be thrown without checking or wrapping in RuntimeException.
+ * (Kotlin does not have concept of checked exceptions, so any Java exception is treated as unchecked).
+ */
+fun <T> uncheck(code : Callable<T>) : T = code.call()
 
 // Private functions can use whatever Kotlin features as Java code will not see them.
 

--- a/components/common/src/test/java/com/hotels/styx/common/io/FileResourceTest.java
+++ b/components/common/src/test/java/com/hotels/styx/common/io/FileResourceTest.java
@@ -29,11 +29,11 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.stream.Stream;
 
-import static com.google.common.io.Files.createTempDir;
-import static com.google.common.io.Files.write;
 import static com.hotels.styx.common.io.ResourceContentMatcher.contains;
 import static io.netty.util.CharsetUtil.UTF_8;
 import static java.io.File.createTempFile;
+import static java.nio.file.Files.createTempDirectory;
+import static java.nio.file.Files.writeString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -50,11 +50,11 @@ public class FileResourceTest {
 
     @BeforeAll
     public void setUp() throws IOException {
-        tempDir = createTempDir();
+        tempDir = createTempDirectory("").toFile();
         tempFile = createTempFile("foo", "bar");
         namedTempFile = new File(tempDir, "test.txt");
-        write(TEMP_FILE_CONTENT, tempFile, UTF_8);
-        write(NAMED_TEMP_FILE_CONTENT, namedTempFile, UTF_8);
+        writeString(tempFile.toPath(), TEMP_FILE_CONTENT, UTF_8);
+        writeString(namedTempFile.toPath(), NAMED_TEMP_FILE_CONTENT, UTF_8);
     }
 
     @AfterAll

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistryFactoryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistryFactoryTest.java
@@ -35,9 +35,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
-import static com.google.common.io.Files.createTempDir;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.copy;
+import static java.nio.file.Files.createTempDirectory;
 import static java.nio.file.Files.delete;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,13 +51,13 @@ import static org.mockito.Mockito.when;
 
 public class FileBackedBackendServicesRegistryFactoryTest {
 
-    private File tempDir;
+    private Path tempDir;
     private Path monitoredFile;
     private Environment environment;
 
     @BeforeEach
     public void setUp() throws Exception {
-        tempDir = createTempDir();
+        tempDir = createTempDirectory("");
         monitoredFile = Paths.get(tempDir.toString(), "origins.yml");
         write(monitoredFile, "content-v1");
         environment = new com.hotels.styx.Environment.Builder().registry(new MicrometerRegistry(new SimpleMeterRegistry())).build();
@@ -66,13 +66,11 @@ public class FileBackedBackendServicesRegistryFactoryTest {
     @AfterEach
     public void tearDown() throws Exception {
         delete(monitoredFile);
-        delete(tempDir.toPath());
+        delete(tempDir);
     }
-
 
     @Test
     public void instantiatesFromYaml() {
-
         environment = new com.hotels.styx.Environment.Builder()
                 .registry(new MicrometerRegistry(new SimpleMeterRegistry()))
                 .configuration(StyxConfig.fromYaml("config: {originsFile: '${CONFIG_LOCATION:classpath:}/conf/origins/backend-factory-origins.yml'}", false))

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileChangeMonitorTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileChangeMonitorTest.java
@@ -27,10 +27,10 @@ import java.nio.file.Paths;
 import java.time.Duration;
 
 import static ch.qos.logback.classic.Level.INFO;
-import static com.google.common.io.Files.createTempDir;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.copy;
+import static java.nio.file.Files.createTempDirectory;
 import static java.nio.file.Files.delete;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,14 +45,14 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class FileChangeMonitorTest {
     private static final Logger LOGGER = getLogger(FileChangeMonitorTest.class);
 
-    private File tempDir;
+    private Path tempDir;
     private Path monitoredFile;
     private FileMonitor.Listener listener;
     private FileChangeMonitor monitor;
 
     @BeforeEach
     public void setUp() throws Exception {
-        tempDir = createTempDir();
+        tempDir = createTempDirectory("");
         monitoredFile = Paths.get(tempDir.toString(), "origins.yml");
         write(monitoredFile, "content-v0");
         listener = mock(FileChangeMonitor.Listener.class);
@@ -69,7 +69,7 @@ public class FileChangeMonitorTest {
             // Pass ...
         }
 
-        delete(tempDir.toPath());
+        delete(tempDir);
     }
 
     @Test

--- a/components/server/src/main/java/com/hotels/styx/server/handlers/StaticFileHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/handlers/StaticFileHandler.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.server.handlers;
 
-import com.google.common.io.Files;
 import com.hotels.styx.api.Eventual;
 import com.hotels.styx.api.HttpHandler;
 import com.hotels.styx.api.HttpInterceptor;
@@ -27,6 +26,7 @@ import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Optional;
 
 import static com.hotels.styx.api.HttpHeaderNames.CONTENT_TYPE;
@@ -81,7 +81,7 @@ public class StaticFileHandler implements HttpHandler {
 
     private static String readLines(File file) {
         try {
-            return Files.toString(file, UTF_8);
+            return Files.readString(file.toPath(), UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/components/server/src/test/java/com/hotels/styx/server/handlers/StaticFileHandlerTest.java
+++ b/components/server/src/test/java/com/hotels/styx/server/handlers/StaticFileHandlerTest.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.server.handlers;
 
-import com.google.common.io.Files;
 import com.hotels.styx.api.LiveHttpRequest;
 import com.hotels.styx.api.LiveHttpResponse;
 import org.junit.jupiter.api.AfterEach;
@@ -45,6 +44,7 @@ import static com.hotels.styx.server.handlers.MediaTypes.WAV_AUDIO;
 import static com.hotels.styx.support.Support.requestContext;
 import static com.hotels.styx.support.api.matchers.HttpStatusMatcher.hasStatus;
 import static com.hotels.styx.support.matchers.IsOptional.isValue;
+import static java.nio.file.Files.createTempDirectory;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class StaticFileHandlerTest {
@@ -52,8 +52,8 @@ public class StaticFileHandlerTest {
     private StaticFileHandler handler;
 
     @BeforeEach
-    public void createWorkingDir() {
-        dir = Files.createTempDir();
+    public void createWorkingDir() throws IOException {
+        dir = createTempDirectory("").toFile();
         handler = new StaticFileHandler(dir);
     }
 

--- a/system-tests/e2e-suite/src/test/java/com/hotels/styx/http/StaticFileOnRealServerIT.java
+++ b/system-tests/e2e-suite/src/test/java/com/hotels/styx/http/StaticFileOnRealServerIT.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.http;
 
-import com.google.common.io.Files;
 import com.google.common.util.concurrent.Service;
 import com.hotels.styx.InetServer;
 import com.hotels.styx.StyxServers;
@@ -38,6 +37,7 @@ import static com.hotels.styx.api.HttpMethod.GET;
 import static com.hotels.styx.common.StyxFutures.await;
 import static com.hotels.styx.server.HttpServers.createHttpServer;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createTempDirectory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -56,14 +56,13 @@ public class StaticFileOnRealServerIT {
     }
 
     @BeforeAll
-    public void startServer() {
-        dir = Files.createTempDir();
+    public void startServer() throws IOException {
+        dir = createTempDirectory("").toFile();
         webServer = createHttpServer(0, new StaticFileHandler(dir));
         guavaService = StyxServers.toGuavaService(webServer);
         guavaService.startAsync().awaitRunning();
         serverEndpoint = toHostAndPort(webServer.inetAddress());
     }
-
 
     @AfterAll
     public void stopServer() {

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/OriginsPathDuplicationOnReloadSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/OriginsPathDuplicationOnReloadSpec.scala
@@ -15,10 +15,6 @@
  */
 package com.hotels.styx.admin
 
-import java.nio.file.StandardCopyOption.REPLACE_EXISTING
-import java.nio.file.{Files, Paths}
-
-import com.google.common.io.Files.createTempDir
 import com.hotels.styx.api.HttpRequest.post
 import com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR
 import com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry
@@ -28,6 +24,9 @@ import com.hotels.styx.{StyxClientSupplier, StyxServer, StyxServerSupport}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 
+import java.nio.file.Files.createTempDirectory
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.nio.file.{Files, Paths}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
@@ -38,7 +37,7 @@ class OriginsPathDuplicationOnReloadSpec extends FunSpec
   with BeforeAndAfterAll
   with Eventually {
 
-  val tempDir = createTempDir()
+  val tempDir = createTempDirectory("").toFile
   val originsOk = fixturesHome(classOf[OriginsPathDuplicationOnReloadSpec], "/conf/origins/origins-correct.yml")
   val originsDuplicatePath = fixturesHome(classOf[OriginsPathDuplicationOnReloadSpec], "/conf/origins/origins-duplicate-path.yml")
   val styxOriginsFile = Paths.get(tempDir.toString, "origins.yml")

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/OriginsReloadCommandSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/admin/OriginsReloadCommandSpec.scala
@@ -15,10 +15,6 @@
  */
 package com.hotels.styx.admin
 
-import java.nio.file.StandardCopyOption.REPLACE_EXISTING
-import java.nio.file.{Files, Paths}
-
-import com.google.common.io.Files.createTempDir
 import com.hotels.styx.api.HttpRequest.post
 import com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR
 import com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry
@@ -28,6 +24,9 @@ import com.hotels.styx.{StyxClientSupplier, StyxServer, StyxServerSupport}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 
+import java.nio.file.Files.createTempDirectory
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.nio.file.{Files, Paths}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
@@ -38,7 +37,7 @@ class OriginsReloadCommandSpec extends FunSpec
   with BeforeAndAfterAll
   with Eventually {
 
-  val tempDir = createTempDir()
+  val tempDir = createTempDirectory("").toFile
   val originsOk = fixturesHome(classOf[OriginsReloadCommandSpec], "/conf/origins/origins-correct.yml")
   val originsNok = fixturesHome(classOf[OriginsReloadCommandSpec], "/conf/origins/origins-incorrect.yml")
   val styxOriginsFile = Paths.get(tempDir.toString, "origins.yml")

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BigFileDownloadSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/BigFileDownloadSpec.scala
@@ -15,8 +15,6 @@
  */
 package com.hotels.styx.proxy
 
-import com.google.common.io.Files
-import com.google.common.io.Files._
 import com.hotels.styx.MockServer.responseSupplier
 import com.hotels.styx.api.HttpHeaderNames.HOST
 import com.hotels.styx.api.HttpRequest.get
@@ -31,6 +29,7 @@ import reactor.core.publisher.Mono
 
 import java.io.{File, IOException, RandomAccessFile}
 import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files.{createTempDirectory, readString}
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import scala.concurrent.duration._
 
@@ -59,7 +58,8 @@ class BigFileDownloadSpec extends FunSpec
     )
 
     val bigFile: File = newBigFile("big_file.dat")
-    fileServer.stub("/download", responseSupplier(() => response(OK).body(Files.toString(bigFile, UTF_8), UTF_8).build().stream))
+
+    fileServer.stub("/download", responseSupplier(() => response(OK).body(readString(bigFile.toPath, UTF_8), UTF_8).build().stream))
   }
 
   override protected def afterAll(): Unit = {
@@ -101,7 +101,7 @@ class BigFileDownloadSpec extends FunSpec
 
   @throws(classOf[IOException])
   private def newBigFile(filename: String): File = {
-    val tmpDir: File = createTempDir
+    val tmpDir: File = createTempDirectory("").toFile
     val tmpFile: String = tmpDir.toPath.resolve(filename).toString
 
     val file: RandomAccessFile = new RandomAccessFile(tmpFile, "rwd")

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/LongDownloadsSpec.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/proxy/resiliency/LongDownloadsSpec.scala
@@ -18,7 +18,6 @@ package com.hotels.styx.proxy.resiliency
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
-import com.google.common.io.Files
 import com.hotels.styx.MockServer.responseSupplier
 import com.hotels.styx._
 import com.hotels.styx.api.HttpResponse
@@ -37,6 +36,8 @@ import org.slf4j.LoggerFactory
 import java.io.{File, IOException, RandomAccessFile}
 import java.net.URL
 import java.nio.charset.StandardCharsets._
+import java.nio.file.Files
+import java.nio.file.Files.readString
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -152,11 +153,11 @@ class LongDownloadsSpec extends org.scalatest.fixture.WordSpec
 object SharedOrigins extends NettyOrigins {
   val FIFTY_MB: Long = 50L * 1024L * 1024L
   val bigFile: File = newBigFile("big_file.dat")
-  val bigFileContent: String = Files.toString(bigFile, UTF_8)
+  val bigFileContent: String = readString(bigFile.toPath, UTF_8)
 
   @throws(classOf[IOException])
   private def newBigFile(filename: String): File = {
-    val tmpDir: File = Files.createTempDir
+    val tmpDir: File = Files.createTempDirectory("").toFile
     val tmpFile: String = tmpDir.toPath.resolve(filename).toString
     val logger = LoggerFactory.getLogger("com.hotels.styx.proxy.resiliency.SharedOrigins")
 


### PR DESCRIPTION
This is a continuation of the Guava removal https://github.com/ExpediaGroup/styx/pull/755

> To reduce the need to continually update third-party dependencies for security vulnerabilities, we can remove dependencies we don't need. Reduced dependencies are also good for Styx, as it is a plugin framework and dependencies can clash with plugins.
> 
> Removing Guava entirely would be a very big PR, so this PR merely reduces it, targeting the use of Guava collections in particular. Future PRs will remove more.
> 
> Many of the Guava methods used are now replicated (or sufficiently approximated) by the Java standard library. Others are easy to implement ourselves, and a few were never needed to begin with.
> 
> These method calls have been replaced or removed.