### PR TITLE
Remove Guava ByteStreams

### DIFF
--- a/components/common/src/main/java/com/hotels/styx/common/Files.java
+++ b/components/common/src/main/java/com/hotels/styx/common/Files.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 
 import static com.google.common.hash.Hashing.md5;
-import static com.google.common.io.ByteStreams.toByteArray;
+import static com.hotels.styx.javaconvenience.UtilKt.bytes;
 
 /**
  * Reads in a file and performs and Md5 hash on it.
@@ -34,7 +34,7 @@ public final class Files {
 
     public static HashCode fileContentMd5(Path path) {
         try (InputStream stream = new FileInputStream(path.toFile())) {
-           return md5().hashBytes(toByteArray(stream));
+           return md5().hashBytes(bytes(stream));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
+++ b/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
@@ -19,6 +19,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.Callable
 import java.util.function.Supplier
+import java.io.InputStream
+import java.io.OutputStream
 import java.util.stream.Stream
 import kotlin.streams.asStream
 
@@ -81,6 +83,16 @@ fun <K, V> orderedMap(vararg entries: com.hotels.styx.common.Pair<K, V>): Map<K,
  * (Kotlin does not have concept of checked exceptions, so any Java exception is treated as unchecked).
  */
 fun <T> uncheck(code : Callable<T>) : T = code.call()
+
+fun copy(from: InputStream, to: OutputStream): Long = from.copyTo(to)
+
+@JvmOverloads
+fun bytes(from: InputStream, closeWhenDone : Boolean = false): ByteArray =
+    if(closeWhenDone) {
+        from.use { it.readAllBytes() }
+    } else {
+        from.readAllBytes()
+    }
 
 // Private functions can use whatever Kotlin features as Java code will not see them.
 

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/FileBackedRegistry.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/FileBackedRegistry.java
@@ -33,10 +33,10 @@ import java.util.function.Supplier;
 
 import static com.google.common.hash.HashCode.fromLong;
 import static com.google.common.hash.Hashing.md5;
-import static com.google.common.io.ByteStreams.toByteArray;
 import static com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.failed;
 import static com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.reloaded;
 import static com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.unchanged;
+import static com.hotels.styx.javaconvenience.UtilKt.bytes;
 import static java.lang.String.format;
 import static java.nio.file.Files.getLastModifiedTime;
 import static java.util.Objects.requireNonNull;
@@ -143,7 +143,7 @@ public class FileBackedRegistry<T extends Identifiable> extends AbstractRegistry
 
     private byte[] readFile() {
         try (InputStream configurationContent = configurationFile.inputStream()) {
-            return toByteArray(configurationContent);
+            return bytes(configurationContent);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistryTest.java
+++ b/components/proxy/src/test/java/com/hotels/styx/proxy/backends/file/FileBackedBackendServicesRegistryTest.java
@@ -43,13 +43,13 @@ import java.util.concurrent.TimeoutException;
 import static ch.qos.logback.classic.Level.ERROR;
 import static ch.qos.logback.classic.Level.INFO;
 import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.io.ByteStreams.toByteArray;
 import static com.hotels.styx.api.extension.service.spi.Registry.Outcome.FAILED;
 import static com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.failed;
 import static com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.reloaded;
 import static com.hotels.styx.api.extension.service.spi.Registry.ReloadResult.unchanged;
 import static com.hotels.styx.common.StyxFutures.await;
 import static com.hotels.styx.common.io.ResourceFactory.newResource;
+import static com.hotels.styx.javaconvenience.UtilKt.bytes;
 import static com.hotels.styx.support.matchers.LoggingEventMatcher.loggingEvent;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -161,17 +161,17 @@ public class FileBackedBackendServicesRegistryTest {
     public void yamlBackendReaderReadsBackendServicesFromByteStream() throws IOException {
         Resource resource = newResource("classpath:/backends/origins.yml");
 
-        Iterable<BackendService> backendServices = new YAMLBackendServicesReader().read(toByteArray(resource.inputStream()));
+        Iterable<BackendService> backendServices = new YAMLBackendServicesReader().read(bytes(resource.inputStream(), true));
 
         assertThat(newArrayList(backendServices).size(), is(3));
     }
 
     @Test
-    public void yamlBackendReaderPropagatesExceptionWhenFailsToReadFromByteStream() throws IOException {
+    public void yamlBackendReaderPropagatesExceptionWhenFailsToReadFromByteStream() {
         Resource resource = newResource("classpath:/backends/origins-with-invalid-path.yml");
 
         assertThrows(RuntimeException.class,
-                () -> new YAMLBackendServicesReader().read(toByteArray(resource.inputStream())));
+                () -> new YAMLBackendServicesReader().read(bytes(resource.inputStream(), true)));
     }
 
     @Test

--- a/components/server/src/main/java/com/hotels/styx/server/handlers/ClassPathResourceHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/handlers/ClassPathResourceHandler.java
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.server.handlers;
 
-import com.google.common.io.ByteStreams;
 import com.hotels.styx.api.HttpInterceptor;
 import com.hotels.styx.api.HttpRequest;
 import com.hotels.styx.api.HttpResponse;
@@ -32,6 +31,7 @@ import static com.hotels.styx.api.HttpResponseStatus.FORBIDDEN;
 import static com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static com.hotels.styx.api.HttpResponseStatus.NOT_FOUND;
 import static com.hotels.styx.api.HttpResponseStatus.OK;
+import static com.hotels.styx.javaconvenience.UtilKt.bytes;
 import static com.hotels.styx.server.handlers.MediaTypes.mediaTypeOf;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -77,7 +77,7 @@ public class ClassPathResourceHandler extends BaseHttpHandler {
                 return error(FORBIDDEN);
             }
 
-            String resourcePath = DOUBLE_SEPARATOR.matcher(resourceRoot + ensureHasPreceedingSlash(request.path().replace(requestPrefix, "")))
+            String resourcePath = DOUBLE_SEPARATOR.matcher(resourceRoot + ensureHasPrecedingSlash(request.path().replace(requestPrefix, "")))
                     .replaceAll(quoteReplacement("/"));
 
             return new HttpResponse.Builder(OK)
@@ -95,14 +95,12 @@ public class ClassPathResourceHandler extends BaseHttpHandler {
         return path.endsWith("/") ? path : path + "/";
     }
 
-    private static String ensureHasPreceedingSlash(String path) {
+    private static String ensureHasPrecedingSlash(String path) {
         return path.startsWith("/") ? path : "/" + path;
     }
 
     private static byte[] resourceBody(String path) throws IOException {
-        try (InputStream stream = classPathResourceAsStream(path)) {
-            return readStream(stream);
-        }
+        return bytes(classPathResourceAsStream(path), true);
     }
 
     private static HttpResponse error(HttpResponseStatus status) {
@@ -119,9 +117,5 @@ public class ClassPathResourceHandler extends BaseHttpHandler {
         }
 
         return stream;
-    }
-
-    private static byte[] readStream(InputStream stream) throws IOException {
-        return ByteStreams.toByteArray(stream);
     }
 }


### PR DESCRIPTION
This is a continuation of the Guava removal https://github.com/ExpediaGroup/styx/pull/755

> To reduce the need to continually update third-party dependencies for security vulnerabilities, we can remove dependencies we don't need. Reduced dependencies are also good for Styx, as it is a plugin framework and dependencies can clash with plugins.
> 
> Removing Guava entirely would be a very big PR, so this PR merely reduces it, targeting the use of Guava collections in particular. Future PRs will remove more.
> 
> Many of the Guava methods used are now replicated (or sufficiently approximated) by the Java standard library. Others are easy to implement ourselves, and a few were never needed to begin with.
> 
> These method calls have been replaced or removed.