### PR TITLE
Remove Guava ThreadFactoryBuilder

### DIFF
--- a/components/common/src/main/java/com/hotels/styx/EventLoopGroups.java
+++ b/components/common/src/main/java/com/hotels/styx/EventLoopGroups.java
@@ -15,24 +15,21 @@
  */
 package com.hotels.styx;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+
+import static com.hotels.styx.javaconvenience.UtilKt.threadFactoryWithIncrementingName;
 
 final class EventLoopGroups {
     private EventLoopGroups() {
     }
 
     public static EventLoopGroup nioEventLoopGroup(int threadsCount, String threadsNameFormat) {
-        return new NioEventLoopGroup(threadsCount, new ThreadFactoryBuilder()
-                .setNameFormat(threadsNameFormat)
-                .build());
+        return new NioEventLoopGroup(threadsCount, threadFactoryWithIncrementingName(threadsNameFormat));
     }
 
     public static EventLoopGroup epollEventLoopGroup(int threadsCount, String threadsNameFormat) {
-        return new EpollEventLoopGroup(threadsCount, new ThreadFactoryBuilder()
-                .setNameFormat(threadsNameFormat)
-                .build());
+        return new EpollEventLoopGroup(threadsCount, threadFactoryWithIncrementingName(threadsNameFormat));
     }
 }

--- a/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
+++ b/components/common/src/main/kotlin/com/hotels/styx/javaconvenience/Util.kt
@@ -22,6 +22,8 @@ import java.util.SortedSet
 import java.util.TreeMap
 import java.util.TreeSet
 import java.util.concurrent.Callable
+import java.util.concurrent.Executors.defaultThreadFactory
+import java.util.concurrent.ThreadFactory
 import java.util.function.Consumer
 import java.util.function.Function
 import java.util.function.Predicate
@@ -122,6 +124,21 @@ fun <K, V> filterSortedMap(original: SortedMap<K, V>, predicate: Predicate<K>): 
 fun <T> concatenatedForEach(first: Iterable<T>, second: Iterable<T>, action: Consumer<T>) {
     first.forEach(action)
     second.forEach(action)
+}
+
+/**
+ * Name format must contain a placeholder for a number.
+ * This number will be 0 for the first thread created an increment by 1 on each new thread.
+ */
+fun threadFactoryWithIncrementingName(nameFormat: String): ThreadFactory {
+    val defaultThreadFactory = defaultThreadFactory()
+    var threadCount = 0
+
+    return ThreadFactory {
+        defaultThreadFactory.newThread(it).apply {
+            name = nameFormat.format(threadCount++)
+        }
+    }
 }
 
 // Private functions can use whatever Kotlin features as Java code will not see them.

--- a/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/DownloadClient.scala
+++ b/system-tests/e2e-suite/src/test/scala/com/hotels/styx/support/DownloadClient.scala
@@ -15,12 +15,9 @@
  */
 package com.hotels.styx.support
 
-import java.net.URL
-
-import akka.actor.FSM.{Failure, Normal}
 import akka.actor.{ActorRef, LoggingFSM}
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.hotels.styx.api.HttpHeaderNames.{CONTENT_LENGTH, HOST, USER_AGENT}
+import com.hotels.styx.javaconvenience.UtilKt
 import com.hotels.styx.support.DownloadClient._
 import io.netty.bootstrap.Bootstrap
 import io.netty.buffer.ByteBuf
@@ -33,6 +30,7 @@ import io.netty.handler.codec.http.HttpVersion.HTTP_1_1
 import io.netty.handler.codec.http._
 import org.slf4j.LoggerFactory
 
+import java.net.URL
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -111,7 +109,7 @@ class DownloadClient extends LoggingFSM[State, Data] {
     }
   }
 
-  val eventLoopGroup = new NioEventLoopGroup(1, new ThreadFactoryBuilder().setNameFormat("Download-Client-%d").build())
+  val eventLoopGroup = new NioEventLoopGroup(1, UtilKt.threadFactoryWithIncrementingName("Download-Client-%d"))
   val bootstrap = new Bootstrap()
     .group(eventLoopGroup)
     .channel(classOf[NioSocketChannel])

--- a/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/HttpTestClient.java
+++ b/system-tests/e2e-testsupport/src/main/java/com/hotels/styx/utils/HttpTestClient.java
@@ -17,7 +17,6 @@ package com.hotels.styx.utils;
 
 import com.google.common.base.Suppliers;
 import com.google.common.net.HostAndPort;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
@@ -35,6 +34,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static com.hotels.styx.javaconvenience.UtilKt.threadFactoryWithIncrementingName;
 import static io.netty.channel.ChannelOption.ALLOCATOR;
 import static io.netty.channel.ChannelOption.AUTO_READ;
 import static io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
@@ -44,7 +44,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class HttpTestClient {
     private static final NioEventLoopGroup EVENT_LOOP_GROUP =
-            new NioEventLoopGroup(1, new ThreadFactoryBuilder().setNameFormat("Test-Client-%d").build());
+            new NioEventLoopGroup(1, threadFactoryWithIncrementingName("Test-Client-%d"));
 
     private final HostAndPort destination;
     private final LinkedBlockingDeque<Object> receivedResponses = new LinkedBlockingDeque<>();


### PR DESCRIPTION
This is a continuation of the Guava removal https://github.com/ExpediaGroup/styx/pull/755

> To reduce the need to continually update third-party dependencies for security vulnerabilities, we can remove dependencies we don't need. Reduced dependencies are also good for Styx, as it is a plugin framework and dependencies can clash with plugins.
> 
> Removing Guava entirely would be a very big PR, so this PR merely reduces it, targeting the use of Guava collections in particular. Future PRs will remove more.
> 
> Many of the Guava methods used are now replicated (or sufficiently approximated) by the Java standard library. Others are easy to implement ourselves, and a few were never needed to begin with.
> 
> These method calls have been replaced or removed.