### PR TITLE
ISSUE-719 fix: cannot run with default.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ wrk2/
 docs/_site
 
 **/.kotlintest/
+
+styx-test/

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=HotelsDotCom/styx)](https://dependabot.com)
 
 Styx is a programmable reverse proxy for JVM (Java Virtual Machine). It can be used
-as a stand-alone application, or as a platform to build custom networking applications. 
+as a stand-alone application, or as a platform to build custom networking applications.
 It is non-blocking, fully asynchronous and event driven therefore very scalable.
 
 ### Features
 
-Styx Proxies HTTP requests to a configurable set of *Backend Services* typically a cluster 
+Styx Proxies HTTP requests to a configurable set of *Backend Services* typically a cluster
 of web servers (multiple origins) or load balancers (e.g. AWS ELB).
 
-Requests are subjected to an *interceptor chain* (conceptualy a HTTP filter chain), which can 
+Requests are subjected to an *interceptor chain* (conceptualy a HTTP filter chain), which can
 respond or modify and pass through the request to the backend services. The interceptor
 chain can be easily extended by *Plugins* written in Java.
 
@@ -51,7 +51,7 @@ info here](https://conferences.oreilly.com/software-architecture/sa-eu/public/sc
 
 ### Quick Start
 
-A [quick-start guide](https://github.com/HotelsDotCom/styx/wiki/Quick-Start-Guide) can be found on our [wiki](https://github.com/HotelsDotCom/styx/wiki). 
+A [quick-start guide](https://github.com/HotelsDotCom/styx/wiki/Quick-Start-Guide) can be found on our [wiki](https://github.com/HotelsDotCom/styx/wiki).
 
 ### User Manual
 
@@ -79,11 +79,10 @@ Contact us via [styx-user](https://groups.google.com/forum/#!forum/styx-user) gr
 
 ## Dependencies
 
-* [Oracle JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) - It can be built with 1.8.0_45. 
-  Earlier maintenance releases may, but are not guaranteed to work.
+* [Oracle JDK 11](https://www.oracle.com/java/technologies/downloads/#java11)
 * [Apache Maven v3](http://maven.apache.org)
-* Makefile (Optional)- There are fairly many ways of running Styx tests with different Maven profiles. Therefore, the 
-  shortcuts for most common usages are compiled into a separate (GNU) Makefile for developer's convenience. To 
+* Makefile (Optional)- There are fairly many ways of running Styx tests with different Maven profiles. Therefore, the
+  shortcuts for most common usages are compiled into a separate (GNU) Makefile for developer's convenience. To
   take advantage of these shortcuts, a GNU Make build tool must be installed.
 
 ## Notice

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/ExpiringConnection.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/ExpiringConnection.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/client/src/main/java/com/hotels/styx/client/connectionpool/ExpiringConnectionFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/connectionpool/ExpiringConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/BackendServiceClientSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/BackendServiceClientSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/OriginSupport.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/OriginSupport.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/RetryHandlingSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/RetryHandlingSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/client/src/test/integration/scala/com/hotels/styx/client/StickySessionSpec.scala
+++ b/components/client/src/test/integration/scala/com/hotels/styx/client/StickySessionSpec.scala
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/ExpiringConnectionTest.java
+++ b/components/client/src/test/unit/java/com/hotels/styx/client/connectionpool/ExpiringConnectionTest.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxServer.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/distribution/conf/default.yml
+++ b/distribution/conf/default.yml
@@ -40,13 +40,15 @@ routingObjects:
   h2Handler:
     type: StaticResponseHandler
     config:
+      status: 200
+      content: "h2-handler"
 
 servers:
   h1Server:
     type: HttpServer
     config:
-      port: 8080
-      listener: h1Handler
+      port: 8081
+      handler: h1Handler
 
       tlsSettings:
         sslProvider: OPENSSL # Also supports JDK
@@ -63,14 +65,11 @@ servers:
       keepAliveTimeoutMillis: 12000
       maxConnectionsCount: 4096
 
-      bossThreadsCount: 1
-      workerThreadsCount: 0
-
   h2Server:
-    type: Http2Server
+    type: HttpServer
     config:
-      port: 8443
-      listener: h2Handler
+      port: 8444
+      handler: h2Handler
 
       maxInitialLength: 4096
       maxHeaderSize: 8192
@@ -80,11 +79,8 @@ servers:
       keepAliveTimeoutMillis: 12000
       maxConnectionsCount: 4096
 
-      bossThreadsCount: 1
-      workerThreadsCount: 0
-
   admin:
     type: HttpServer
     config:
-      port: 9000
-      listener: adminHandler
+      port: 9001
+      handler: adminHandler

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -35,7 +35,7 @@ If `styx-test/` already exists, remove it first to avoid conflicts on dependenci
 
 Let's unzip this file:
 
-    $ unzip distribution/target/styx.zip -d styx-test
+    $ unzip distribution/target/styx-<VERSION>-<OS>-<PLATFORM>.zip -d styx-test
 
 
 ## 1.4 Running Styx

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -8,8 +8,7 @@ In this guide we will walk through how to build applications on top of Styx.
 
 ## 1.2 System Requirements
 
-Building Styx requires Java 1.8. It can be built with 1.8.0_45. Earlier maintenance
-releases may, but are not guaranteed to work.
+Building Styx requires Java 11.
 
 The build system requires Apache Maven. The Styx team uses Maven version 3.2.1
 for automated continuous integration builds. On Mac OSX, a version installed
@@ -30,6 +29,10 @@ To build for Linux, you need to override a *PLATFORM* argument, like so:
 
     $ make release-no-tests PLATFORM=linux
 
+If `styx-test/` already exists, remove it first to avoid conflicts on dependencies:
+
+    $ rm -rf styx-test
+
 Let's unzip this file:
 
     $ unzip distribution/target/styx.zip -d styx-test
@@ -43,19 +46,19 @@ Now, start the styx server:
     Running Styx startup...
     ...
     /plenty of output/
-    ...    
+    ...
 
 Note `APP_originsFile` specifies a Styx origins file path. It substitutes a placeholder
 in the default server configuration file `styx-test/styx/conf/default.yml`. Normally
-you would just specify the path in a server configuration itself, either as an absolute 
-path, or a path relative to the Styx server working directory. But for now we'll just pass 
-it in to start the server from your project working directory. 
+you would just specify the path in a server configuration itself, either as an absolute
+path, or a path relative to the Styx server working directory. But for now we'll just pass
+it in to start the server from your project working directory.
 
 Finally you will see:
 
     INFO  2017-10-13 14:56:24 [c.h.s.s.n.NettyServer] [Admin-Boss-0-Thread] - server connector class com.hotels.styx.server.netty.WebServerConnectorFactory$WebServerConnector bound successfully on port 9000
     INFO  2017-10-13 14:56:24 [c.h.s.StyxServer] [main] - Started styx server in 68ms
-    
+
 
 Once Styx server has started, the admin dashboard is available at http://localhost:9000/.
 You are presented with the Styx admin root interface which shows various

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -2,8 +2,7 @@
 
 ## System Requirements
 
-Running Styx requires Java 1.8. It can be run with 1.8.0_45 or later versions. Earlier maintenance
-releases or Java 1.9 may work, but are not guaranteed to.
+Running Styx requires Java 11.
 
 ## Downloading Styx from release
 
@@ -12,7 +11,7 @@ Alternatively, you can build styx from source code.
 
 ## Building Styx from source code
 
- In order to build styx from source code, Java 8 (1.8.0_45 or later) is required.
+ In order to build styx from source code, Java 11 is required.
  The build system requires Apache Maven. The Styx CI pipeline uses Maven version 3.2.1
  for the automated continuous integration builds. On Mac OSX, a version installed
  by HomeBrew is satisfactory.

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <micrometer.version>1.8.0</micrometer.version>
     <antlr.version>4.5.1-1</antlr.version>
     <netty.version>4.1.74.Final</netty.version>
-    <netty-tcnative.version>2.0.26.Final</netty-tcnative.version>
+    <netty-tcnative.version>2.0.48.Final</netty-tcnative.version>
     <rxjava.version>1.1.6</rxjava.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <reactor.version>3.3.0.RELEASE</reactor.version>
@@ -341,7 +341,7 @@
         <artifactId>byte-buddy</artifactId>
         <version>${bytebuddy.version}</version>
       </dependency>
-      
+
       <!-- Metrics -->
       <dependency>
         <groupId>io.micrometer</groupId>


### PR DESCRIPTION
Resolves: #719 

- fix: incorrect yml config in default.yml
- fix: incompatible version of netty-tcnative
- chore: adding build files to .gitignore

Updated the version of dependency - netty-tcnative-boringssl-static because of the incompatibility between netty-tcnative-boringssl-static and netty.
![Screenshot 2022-03-17 at 11 01 36](https://user-images.githubusercontent.com/100784224/158815394-9787f9ce-db0d-47eb-89d4-145916bb04d7.png)

Also, the outdated config properties in default.yml has been removed or renamed to match the current schema requirements, e.g. settings in https://github.com/ExpediaGroup/styx/blob/master/components/proxy/src/main/java/com/hotels/styx/ServerConfigSchema.java and https://github.com/ExpediaGroup/styx/blob/master/components/proxy/src/main/kotlin/com/hotels/styx/servers/StyxHttpServer.kt.

Some of the ports in the default configs are also changed to prevent conflicts against some other ports which have been listened to.
