### PR TITLE
feat: top level rewrite support

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/BuiltInInterceptors.java
+++ b/components/proxy/src/main/java/com/hotels/styx/BuiltInInterceptors.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import com.hotels.styx.proxy.interceptors.RequestEnrichingInterceptor;
 import com.hotels.styx.proxy.interceptors.TcpTunnelRequestRejector;
 import com.hotels.styx.proxy.interceptors.UnexpectedRequestContentLengthRemover;
 import com.hotels.styx.proxy.interceptors.ViaHeaderAppendingInterceptor;
+import com.hotels.styx.routing.interceptors.RewriteInterceptor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +50,10 @@ final class BuiltInInterceptors {
 
         if (loggingEnabled) {
             builder.add(new HttpMessageLoggingInterceptor(longFormatEnabled, httpMessageFormatter));
+        }
+
+        if (config.rewriteGroupsConfig() != null) {
+            builder.add(new RewriteInterceptor.Factory().build(config.rewriteGroupsConfig()));
         }
 
         builder.addAll(asList(new TcpTunnelRequestRejector(),

--- a/components/proxy/src/main/java/com/hotels/styx/ServerConfigSchema.java
+++ b/components/proxy/src/main/java/com/hotels/styx/ServerConfigSchema.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import static com.hotels.styx.config.schema.SchemaDsl.map;
 import static com.hotels.styx.config.schema.SchemaDsl.object;
 import static com.hotels.styx.config.schema.SchemaDsl.opaque;
 import static com.hotels.styx.config.schema.SchemaDsl.optional;
+import static com.hotels.styx.config.schema.SchemaDsl.or;
 import static com.hotels.styx.config.schema.SchemaDsl.routingObject;
 import static com.hotels.styx.config.schema.SchemaDsl.string;
 import static com.hotels.styx.config.schema.SchemaDsl.union;
@@ -162,7 +163,14 @@ final class ServerConfigSchema {
                                     optional("name", string()),
                                     field("type", string()),
                                     optional("tags", list(string())),
-                                    optional("config", union("type")))))
+                                    optional("config", union("type"))))),
+                            optional("rewrites", or(
+                                map(list(object(
+                                    field("urlPattern", string()),
+                                    field("replacement", string())
+                                ))),
+                                object(field("configFile", string())))
+                            )
                     ));
 
         BUILTIN_HANDLER_SCHEMAS.forEach(STYX_SERVER_CONFIGURATION_SCHEMA_BUILDER::typeExtension);

--- a/components/proxy/src/main/java/com/hotels/styx/StyxConfig.java
+++ b/components/proxy/src/main/java/com/hotels/styx/StyxConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.hotels.styx.config.schema.SchemaValidationException;
 import com.hotels.styx.infrastructure.configuration.ConfigurationParser;
 import com.hotels.styx.infrastructure.configuration.yaml.YamlConfiguration;
 import com.hotels.styx.proxy.ProxyServerConfig;
+import com.hotels.styx.routing.config.RewriteGroupsConfig;
 import org.slf4j.Logger;
 
 import java.nio.file.Path;
@@ -53,6 +54,7 @@ public final class StyxConfig implements Configuration {
     private final ProxyServerConfig proxyServerConfig;
     private final AdminServerConfig adminServerConfig;
     private final StyxHeaderConfig styxHeaderConfig;
+    private final RewriteGroupsConfig rewriteGroupsConfig;
 
     public StyxConfig() {
         this(EMPTY_CONFIGURATION);
@@ -63,6 +65,7 @@ public final class StyxConfig implements Configuration {
         this.adminServerConfig = get("admin", AdminServerConfig.class).orElseGet(AdminServerConfig::new);
         this.proxyServerConfig = get("proxy", ProxyServerConfig.class).orElseGet(ProxyServerConfig::new);
         this.styxHeaderConfig = get("styxHeaders", StyxHeaderConfig.class).orElseGet(StyxHeaderConfig::new);
+        this.rewriteGroupsConfig = get("rewrites", RewriteGroupsConfig.class).orElse(null);
     }
 
     @Override
@@ -90,6 +93,10 @@ public final class StyxConfig implements Configuration {
 
     public AdminServerConfig adminServerConfig() {
         return adminServerConfig;
+    }
+
+    public RewriteGroupsConfig rewriteGroupsConfig() {
+        return rewriteGroupsConfig;
     }
 
     public int port() {

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/yaml/YamlConfiguration.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/yaml/YamlConfiguration.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -133,6 +133,7 @@ public class YamlConfiguration implements ExtensibleConfiguration<YamlConfigurat
 
     private static <T> T parseNodeToClass(JsonNode node, Class<T> tClass) {
         JsonParser parser = node.traverse();
+        parser.setCodec(YAML_MAPPER);
 
         try {
             return YAML_MAPPER.readValue(parser, tClass);

--- a/components/proxy/src/main/java/com/hotels/styx/routing/interceptors/RewriteInterceptor.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/interceptors/RewriteInterceptor.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2022 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,10 +25,12 @@ import com.hotels.styx.client.RewriteRuleset;
 import com.hotels.styx.config.schema.Schema;
 import com.hotels.styx.infrastructure.configuration.yaml.JsonNodeConfig;
 import com.hotels.styx.routing.config.HttpInterceptorFactory;
+import com.hotels.styx.routing.config.RewriteGroupsConfig;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.hotels.styx.config.schema.SchemaDsl.field;
 import static com.hotels.styx.config.schema.SchemaDsl.list;
@@ -73,5 +75,15 @@ public class RewriteInterceptor implements HttpInterceptor {
             return new RewriteInterceptor(new RewriteRuleset(List.copyOf(rules)));
         }
 
+        public HttpInterceptor build(RewriteGroupsConfig rewriteGroupsConfig) {
+            return new RewriteInterceptor(
+                new RewriteRuleset(
+                    rewriteGroupsConfig.values()
+                        .stream()
+                        .flatMap(List::stream)
+                        .collect(Collectors.toList())
+                )
+            );
+        }
     }
 }

--- a/components/proxy/src/main/kotlin/com/hotels/styx/routing/config/RewriteGroupsConfig.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/routing/config/RewriteGroupsConfig.kt
@@ -1,0 +1,80 @@
+/*
+  Copyright (C) 2013-2022 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.routing.config
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.hotels.styx.api.Resource
+import com.hotels.styx.api.extension.service.RewriteConfig
+import com.hotels.styx.api.extension.service.RewriteRule
+import com.hotels.styx.common.io.ResourceFactory.newResource
+import com.hotels.styx.infrastructure.configuration.ConfigurationParser
+import com.hotels.styx.infrastructure.configuration.ConfigurationSource
+import com.hotels.styx.infrastructure.configuration.yaml.YamlConfiguration
+import com.hotels.styx.infrastructure.configuration.yaml.YamlConfigurationFormat
+
+@JsonDeserialize(using = RewriteGroupsConfigDeserializer::class)
+class RewriteGroupsConfig(
+    groups: Map<String, List<RewriteRule>>? = mapOf()
+): HashMap<String, List<RewriteRule>>(groups)
+
+private class RewriteGroupsConfigDeserializer: JsonDeserializer<RewriteGroupsConfig>() {
+
+    companion object {
+        private const val CONFIG_FILE = "configFile"
+        private const val URL_PATTERN = "urlPattern"
+        private const val REPLACEMENT = "replacement"
+        private const val UNCHECKED_CAST = "UNCHECKED_CAST"
+    }
+
+    @Suppress(UNCHECKED_CAST)
+    private val toRewriteConfigGroups: (Map.Entry<Any?, Any?>) -> Pair<String, List<RewriteConfig>> = {
+        val configs: List<RewriteConfig> = (it.value as List<Map<String, String>>)
+            .map { configNode ->
+                RewriteConfig(
+                    configNode[URL_PATTERN],
+                    configNode[REPLACEMENT]
+                )
+            }
+        it.key as String to configs
+    }
+
+    override fun deserialize(jsonParser: JsonParser?, context: DeserializationContext): RewriteGroupsConfig {
+        val node: JsonNode = jsonParser?.readValueAsTree() ?: return RewriteGroupsConfig()
+        val yamlConfig: YamlConfiguration =
+            if (node.has(CONFIG_FILE))
+                loadYamlConfiguration(newResource(node.get(CONFIG_FILE).asText()))
+            else
+                YamlConfiguration(node)
+
+        val groups: Map<String, List<RewriteConfig>> =
+            yamlConfig.`as`(Map::class.java)
+                .map(toRewriteConfigGroups)
+                .toMap()
+
+        return RewriteGroupsConfig(groups)
+    }
+
+    private fun loadYamlConfiguration(yaml: Resource): YamlConfiguration =
+        ConfigurationParser.Builder<YamlConfiguration>()
+            .format(YamlConfigurationFormat.YAML)
+            .overrides(System.getProperties())
+            .build()
+            .parse(ConfigurationSource.configSource(yaml))
+}

--- a/components/proxy/src/test/kotlin/com/hotels/styx/routing/config/RewriteGroupsConfigDeserializerTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/routing/config/RewriteGroupsConfigDeserializerTest.kt
@@ -1,0 +1,70 @@
+/*
+  Copyright (C) 2013-2022 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.routing.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.hotels.styx.api.extension.service.RewriteConfig
+import com.hotels.styx.support.ResourcePaths
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+
+class RewriteGroupsConfigDeserializerTest : StringSpec() {
+
+    companion object {
+        private val REWRITES_FILE = ResourcePaths.fixturesHome() + "conf/rewrites.yml"
+        private val OBJECT_MAPPER: ObjectMapper = ObjectMapper(YAMLFactory())
+    }
+
+    init {
+        "deserialize when rewrite list is passed directly to styx config" {
+            val yaml = """
+                someGroup:
+                    - urlPattern: "/foo/(.*)"
+                      replacement: "/bar/$1"
+                    - urlPattern: "/ping/(.*)"
+                      replacement: "/pong/$1"
+                anotherGroup:
+                    - urlPattern: "/hey/(.*)"
+                      replacement: "/hi/$1"
+            """
+            val rewriteGroupsConfig = OBJECT_MAPPER.readValue(yaml, RewriteGroupsConfig::class.java)
+            rewriteGroupsConfig.size shouldBe 2
+            rewriteGroupsConfig["someGroup"] shouldBe listOf(
+                RewriteConfig("/foo/(.*)", "/bar/$1"),
+                RewriteConfig("/ping/(.*)", "/pong/$1")
+            )
+            rewriteGroupsConfig["anotherGroup"] shouldBe listOf(
+                RewriteConfig("/hey/(.*)", "/hi/$1")
+            )
+        }
+
+        "deserialize when rewrite config file path is passed" {
+            val yaml = """
+                configFile: "$REWRITES_FILE"
+            """
+            val rewriteGroupsConfig = OBJECT_MAPPER.readValue(yaml, RewriteGroupsConfig::class.java)
+            rewriteGroupsConfig.size shouldBe 2
+            rewriteGroupsConfig["someGroup"] shouldBe listOf(
+                RewriteConfig("/foo/(.*)", "/bar/$1"),
+                RewriteConfig("/ping/(.*)", "/pong/$1")
+            )
+            rewriteGroupsConfig["anotherGroup"] shouldBe listOf(
+                RewriteConfig("/hey/(.*)", "/hi/$1")
+            )
+        }
+    }
+}

--- a/components/proxy/src/test/resources/conf/rewrites.yml
+++ b/components/proxy/src/test/resources/conf/rewrites.yml
@@ -1,0 +1,10 @@
+---
+
+someGroup:
+  - urlPattern: "/foo/(.*)"
+    replacement: "/bar/$1"
+  - urlPattern: "/ping/(.*)"
+    replacement: "/pong/$1"
+anotherGroup:
+  - urlPattern: "/hey/(.*)"
+    replacement: "/hi/$1"

--- a/docs/user-guide/configure-overview.md
+++ b/docs/user-guide/configure-overview.md
@@ -188,4 +188,18 @@ plugins:
       config:
         some: "config"
         et: "cetera"
+
+# Optional configuration for top level rewrite rules
+# requests will be rewritten before hitting origins/httpPipeline
+# either configFile path or groups of rewrite rules will need to be specified
+rewrites:
+  group1:
+    - urlPattern: "/foo/(.*)"
+    - replacement: "/bar/$1"
+  group2:
+    - urlPattern: "/ping/(.*)"
+    - replacement: "/pong/$1"
+# or rules can be specified under a file as follows
+# rewrites:
+#   configFile: "/foo/bar/rewrite.yml"
  ```


### PR DESCRIPTION
- adding RewriteInterceptor to builtin intercepters

<!--
Thank you for submitting a pull request!

Please verify that:
* [v] Code is up-to-date with the `main` branch.
* [v] You've successfully built and run the tests locally.
* [v] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- This PR is to support top level rewrites before hitting origins.
- StyxConfig ("/foo/bar/default.yml") example:

```
...
rewrites:
  configFile: "${rewriteFile}" # "/foo/bar/rewrites.yml"
...
```
or
```
...
rewrites:
  test-group:
    - urlPattern: "/local/(.*)"
      replacement: "/123"
    - urlPattern: "/wow/(.*)"
      replacement: "/123"
  some-other:
    - urlPattern: "/yeh/(.*)"
      replacement: "/haha"
    - urlPattern: "/oh/(.*)"
      replacement: "/go"
...
```

- Rewrites config file ("/foo/bar/rewrites.yml") example:

```
...
test-group:
  - urlPattern: "/local/(.*)"
    replacement: "/123"
  - urlPattern: "/wow/(.*)"
    replacement: "/123"
some-other:
  - urlPattern: "/yeh/(.*)"
    replacement: "/haha"
  - urlPattern: "/oh/(.*)"
    replacement: "/go"
...
```

