### PR TITLE
fix: overrideHostHeader not being consumed by HostProxy if default backend service is used for httpPipelines

### DIFF
--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsConfigConverter.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsConfigConverter.kt
@@ -144,7 +144,8 @@ internal class OriginsConfigConverter(
                         app.responseTimeoutMillis(),
                         app.maxHeaderSize(),
                         origin,
-                        "origins"))
+                        "origins",
+                        app.isOverrideHostHeader()))
     }
 
     private fun hostProxyConfig(poolSettings: ConnectionPoolSettings,
@@ -152,7 +153,8 @@ internal class OriginsConfigConverter(
                                 responseTimeout: Int,
                                 maxHeaderSize: Int,
                                 origin: Origin,
-                                metricsPrefix: String): JsonNode = MAPPER.valueToTree(
+                                metricsPrefix: String,
+                                overrideHostHeader: Boolean): JsonNode = MAPPER.valueToTree(
             HostProxyConfiguration(
                     "${origin.host()}:${origin.port()}",
                     poolSettings,
@@ -160,7 +162,8 @@ internal class OriginsConfigConverter(
                     responseTimeout,
                     maxHeaderSize,
                     metricsPrefix,
-                    executor))
+                    executor,
+                    overrideHostHeader))
 
     companion object {
         val LOGGER = LoggerFactory.getLogger(this::class.java)

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsConfigConverterTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/OriginsConfigConverterTest.kt
@@ -57,17 +57,48 @@ class OriginsConfigConverterTest : StringSpec({
                     it[0].type().shouldBe("HostProxy")
                     it[0].config().shouldNotBeNull()
                     it[0].config()["maxHeaderSize"].intValue() shouldBe 1000
+                    it[0].config()["overrideHostHeader"].booleanValue() shouldBe false
 
                     it[1].name() shouldBe "app.app2"
                     it[1].tags().shouldContainExactlyInAnyOrder(lbGroupTag("app"), stateTag(STATE_ACTIVE))
                     it[1].type().shouldBe("HostProxy")
                     it[1].config().shouldNotBeNull()
+                    it[1].config()["maxHeaderSize"].intValue() shouldBe 1000
+                    it[1].config()["overrideHostHeader"].booleanValue() shouldBe false
 
                     it[2].name() shouldBe "app"
                     it[2].tags().shouldBeEmpty()
                     it[2].type().shouldBe("LoadBalancingGroup")
                     it[2].config().shouldNotBeNull()
                 }
+    }
+
+    "Translates a HostProxy object with overrideHostHeader" {
+        val config = """
+            ---
+            - id: "app"
+              path: "/"
+              origins:
+              - { id: "app1", host: "localhost:9090" }
+              overrideHostHeader: true
+            """.trimIndent()
+
+        OriginsConfigConverter(serviceDb, ctx, "")
+            .routingObjects(deserialiseOrigins(config))
+            .let {
+                it.size shouldBe 2
+
+                it[0].name() shouldBe "app.app1"
+                it[0].tags().shouldContainExactlyInAnyOrder(lbGroupTag("app"), stateTag(STATE_ACTIVE))
+                it[0].type().shouldBe("HostProxy")
+                it[0].config().shouldNotBeNull()
+                it[0].config()["overrideHostHeader"].booleanValue() shouldBe true
+
+                it[1].name() shouldBe "app"
+                it[1].tags().shouldBeEmpty()
+                it[1].type().shouldBe("LoadBalancingGroup")
+                it[1].config().shouldNotBeNull()
+            }
     }
 
     "Translates one rewrite rules" {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [v] Code is up-to-date with the `main` branch.
* [v] You've successfully built and run the tests locally.
* [v] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- To make it recognise overrideHostHeader in orgins.yaml if YamlFileConfigurationService is used

### :link: Related Issues
- 
