### PR TITLE
fix: modify tcp keep alive idle time to avoid connection dropped by requested servers

### DIFF
--- a/components/api/pom.xml
+++ b/components/api/pom.xml
@@ -95,6 +95,11 @@
       <artifactId>reactor-test</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.kotlintest</groupId>
+      <artifactId>kotlintest-runner-junit5</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/components/api/src/main/kotlin/com/hotels/styx/api/extension/service/TcpKeepAliveSettings.kt
+++ b/components/api/src/main/kotlin/com/hotels/styx/api/extension/service/TcpKeepAliveSettings.kt
@@ -1,0 +1,81 @@
+/*
+  Copyright (C) 2013-2023 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.api.extension.service
+
+import java.lang.StringBuilder
+
+/**
+ * Programmatically configurable TCP keepalive settings.
+ */
+data class TcpKeepAliveSettings(
+    val keepAliveIdleTimeSeconds: Int?,
+    val keepAliveIntervalSeconds: Int?,
+    val keepAliveRetryCount: Int?
+) {
+    private constructor(builder: Builder) : this(
+        keepAliveIdleTimeSeconds = builder.keepAliveIdleTimeSeconds,
+        keepAliveIntervalSeconds = builder.keepAliveIntervalSeconds,
+        keepAliveRetryCount = builder.keepAliveRetryCount
+    )
+
+    /**
+     * A builder for [TcpKeepAliveSettings].
+     */
+    class Builder(
+        var keepAliveIdleTimeSeconds: Int? = null,
+        var keepAliveIntervalSeconds: Int? = null,
+        var keepAliveRetryCount: Int? = null
+    ) {
+        constructor(tcpKeepAliveSettings: TcpKeepAliveSettings) : this() {
+            this.keepAliveIdleTimeSeconds = tcpKeepAliveSettings.keepAliveIdleTimeSeconds
+            this.keepAliveIntervalSeconds = tcpKeepAliveSettings.keepAliveIntervalSeconds
+            this.keepAliveRetryCount = tcpKeepAliveSettings.keepAliveRetryCount
+        }
+
+        fun keepAliveIdleTimeSeconds(keepAliveIdleTimeSeconds: Int?) = apply {
+            this.keepAliveIdleTimeSeconds = keepAliveIdleTimeSeconds
+        }
+
+        fun keepAliveIntervalSeconds(keepAliveIntervalSeconds: Int?) = apply {
+            this.keepAliveIntervalSeconds = keepAliveIntervalSeconds
+        }
+
+        fun keepAliveRetryCount(keepAliveRetryCount: Int?) = apply {
+            this.keepAliveRetryCount = keepAliveRetryCount
+        }
+
+        fun build() = TcpKeepAliveSettings(this)
+    }
+
+    fun keepAliveIdleTimeSeconds(): Int? = keepAliveIdleTimeSeconds
+
+    fun keepAliveIntervalSeconds(): Int? = keepAliveIntervalSeconds
+
+    fun keepAliveRetryCount(): Int? = keepAliveRetryCount
+
+    fun newCopy(): Builder = Builder(this)
+
+    override fun toString(): String = StringBuilder(128)
+        .append(this.javaClass.simpleName)
+        .append("{keepAliveIdleTimeSeconds=")
+        .append(keepAliveIdleTimeSeconds)
+        .append(", keepAliveIntervalSeconds=")
+        .append(keepAliveIntervalSeconds)
+        .append(", keepAliveRetryCount=")
+        .append(keepAliveRetryCount)
+        .append("}")
+        .toString()
+}

--- a/components/api/src/test/kotlin/com.hotels.styx.api.extension/TcpKeepAliveSettingsTest.kt
+++ b/components/api/src/test/kotlin/com.hotels.styx.api.extension/TcpKeepAliveSettingsTest.kt
@@ -1,0 +1,41 @@
+/*
+  Copyright (C) 2013-2023 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.api.extension
+
+import com.hotels.styx.api.extension.service.TcpKeepAliveSettings
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+
+class TcpKeepAliveSettingsTest : StringSpec({
+    "setsConfigurationValues" {
+        val config = TcpKeepAliveSettings(100, 30, 3)
+
+        config.keepAliveIdleTimeSeconds() shouldBe 100
+        config.keepAliveIntervalSeconds() shouldBe 30
+        config.keepAliveRetryCount() shouldBe 3
+    }
+
+    "shouldBuildFromOtherTcpKeepAliveSettings" {
+        val config = TcpKeepAliveSettings(120, 60, 8)
+        val newConfig = TcpKeepAliveSettings.Builder(config)
+            .keepAliveIdleTimeSeconds(20)
+            .build()
+
+        newConfig.keepAliveIdleTimeSeconds() shouldBe 20
+        newConfig.keepAliveIntervalSeconds() shouldBe 60
+        newConfig.keepAliveRetryCount() shouldBe 8
+    }
+})

--- a/components/client/src/main/java/com/hotels/styx/client/HttpConfig.java
+++ b/components/client/src/main/java/com/hotels/styx/client/HttpConfig.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2023 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package com.hotels.styx.client;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 /**
@@ -26,12 +25,12 @@ public final class HttpConfig {
     private static final int USE_DEFAULT_MAX_HEADER_SIZE = 0;
     private static final int DEFAULT_MAX_HEADER_SIZE = 32678;
 
-    private boolean compress;
+    private final boolean compress;
     private final int maxInitialLength;
     private final int maxHeadersSize;
     private final int maxChunkSize;
-    private int maxContentLength;
-    private Iterable<ChannelOptionSetting> settings;
+    private final int maxContentLength;
+    private final Iterable<ChannelOptionSetting<?>> settings;
 
 
     private HttpConfig(Builder builder) {
@@ -95,7 +94,7 @@ public final class HttpConfig {
      *
      * @return netty channel options
      */
-    public Iterable<ChannelOptionSetting> channelSettings() {
+    public Iterable<ChannelOptionSetting<?>> channelSettings() {
         return settings;
     }
 
@@ -126,7 +125,7 @@ public final class HttpConfig {
         private int maxHeadersSize = DEFAULT_MAX_HEADER_SIZE;
         private int maxChunkSize = 32768;
         private int maxContentLength = 65536;
-        private Iterable<ChannelOptionSetting> settings = emptyList();
+        private Iterable<ChannelOptionSetting<?>> settings = emptyList();
 
         private Builder() {
         }
@@ -181,8 +180,8 @@ public final class HttpConfig {
          * @param settings netty channel options
          * @return this builder
          */
-        public Builder setSettings(ChannelOptionSetting... settings) {
-            this.settings = asList(settings);
+        public Builder setSettings(Iterable<ChannelOptionSetting<?>> settings) {
+            this.settings = settings;
             return this;
         }
 

--- a/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnectionFactory.java
+++ b/components/client/src/main/java/com/hotels/styx/client/netty/connectionpool/NettyConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2023 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,7 +30,11 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
+import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.handler.ssl.SslContext;
+import jdk.net.ExtendedSocketOptions;
 import reactor.core.publisher.Mono;
 
 import java.util.Optional;
@@ -48,6 +52,12 @@ import static java.util.Objects.requireNonNull;
  */
 public class NettyConnectionFactory implements Connection.Factory {
 
+    // Linux has TCP_KEEPALIVE_IDLE_TIME set to 7200 seconds by default.
+    // We need to set this to smaller than the idle timeout of server/upstream
+    // to avoid TransportLostException
+    private static final int TCP_KEEPALIVE_IDLE_TIME = 240;
+    private static final int TCP_KEEPALIVE_INTERVAL = 30;
+    private static final int TCP_KEEPALIVE_RETRY_COUNT = 3;
     private final HttpConfig httpConfig;
     private final SslContext sslContext;
     private final boolean sendSni;
@@ -100,6 +110,17 @@ public class NettyConnectionFactory implements Connection.Factory {
                     .option(SO_KEEPALIVE, true)
                     .option(ALLOCATOR, PooledByteBufAllocator.DEFAULT)
                     .option(CONNECT_TIMEOUT_MILLIS, connectionSettings.connectTimeoutMillis());
+
+            if (Epoll.isAvailable()) {
+                bootstrap.option(EpollChannelOption.TCP_KEEPIDLE, TCP_KEEPALIVE_IDLE_TIME)
+                        .option(EpollChannelOption.TCP_KEEPINTVL, TCP_KEEPALIVE_INTERVAL)
+                        .option(EpollChannelOption.TCP_KEEPCNT, TCP_KEEPALIVE_RETRY_COUNT);
+            } else {
+                bootstrap.option(NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE), TCP_KEEPALIVE_IDLE_TIME)
+                        .option(NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPINTERVAL), TCP_KEEPALIVE_INTERVAL)
+                        .option(NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT), TCP_KEEPALIVE_RETRY_COUNT);
+            }
+
             for (ChannelOptionSetting setting : httpConfig.channelSettings()) {
                 bootstrap.option(setting.option(), setting.value());
             }

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/json/ObjectMappers.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/json/ObjectMappers.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2023 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
 import com.hotels.styx.api.extension.service.HealthCheckConfig;
 import com.hotels.styx.api.extension.service.RewriteConfig;
 import com.hotels.styx.api.extension.service.StickySessionConfig;
+import com.hotels.styx.api.extension.service.TcpKeepAliveSettings;
 import com.hotels.styx.api.extension.service.TlsSettings;
 import com.hotels.styx.infrastructure.configuration.json.mixins.BackendServiceMixin;
 import com.hotels.styx.infrastructure.configuration.json.mixins.CertificateMixin;
@@ -35,6 +36,7 @@ import com.hotels.styx.infrastructure.configuration.json.mixins.OriginMixin;
 import com.hotels.styx.infrastructure.configuration.json.mixins.OriginsSnapshotMixin;
 import com.hotels.styx.infrastructure.configuration.json.mixins.RewriteConfigMixin;
 import com.hotels.styx.infrastructure.configuration.json.mixins.StickySessionConfigMixin;
+import com.hotels.styx.infrastructure.configuration.json.mixins.TcpKeepAliveSettingsMixin;
 import com.hotels.styx.infrastructure.configuration.json.mixins.TlsSettingsMixin;
 
 
@@ -65,7 +67,9 @@ public final class ObjectMappers {
                 .addMixIn(TlsSettings.Builder.class, TlsSettingsMixin.Builder.class)
                 .addMixIn(Origin.class, OriginMixin.class)
                 .addMixIn(OriginsSnapshot.class, OriginsSnapshotMixin.class)
-                .addMixIn(Id.class, IdMixin.class);
+                .addMixIn(Id.class, IdMixin.class)
+                .addMixIn(TcpKeepAliveSettings.class, TcpKeepAliveSettingsMixin.class)
+                .addMixIn(TcpKeepAliveSettings.Builder.class, TcpKeepAliveSettingsMixin.Builder.class);
         return objectMapper;
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/json/mixins/BackendServiceMixin.java
+++ b/components/proxy/src/main/java/com/hotels/styx/infrastructure/configuration/json/mixins/BackendServiceMixin.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2023 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
 import com.hotels.styx.api.extension.service.HealthCheckConfig;
 import com.hotels.styx.api.extension.service.RewriteConfig;
 import com.hotels.styx.api.extension.service.StickySessionConfig;
+import com.hotels.styx.api.extension.service.TcpKeepAliveSettings;
 import com.hotels.styx.api.extension.service.TlsSettings;
 
 import java.util.List;
@@ -66,6 +67,12 @@ public interface BackendServiceMixin {
     @JsonProperty("tlsSettings")
     TlsSettings getTlsSettings();
 
+    @JsonProperty("overrideHostHeader")
+    boolean overrideHostHeader();
+
+    @JsonProperty("tcpKeepAliveSettings")
+    TcpKeepAliveSettings tcpKeepAliveSettings();
+
     /**
      * Jackson annotations for {@link BackendService.Builder}.
      */
@@ -103,5 +110,11 @@ public interface BackendServiceMixin {
 
         @JsonProperty("healthCheck")
         BackendService.Builder healthCheckConfig(HealthCheckConfig healthCheckConfig);
+
+        @JsonProperty("overrideHostHeader")
+        BackendService.Builder overrideHostHeader(boolean overrideHostHeader);
+
+        @JsonProperty("tcpKeepAliveSettings")
+        BackendService.Builder tcpKeepAliveSettings(TcpKeepAliveSettings tcpKeepAliveSettings);
     }
 }

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
@@ -122,7 +122,10 @@ public class HostProxy implements RoutingObject {
             optional("tcpKeepAliveSettings", object(
                     optional("keepAliveIdleTimeSeconds", integer()),
                     optional("keepAliveIntervalSeconds", integer()),
-                    optional("keepAliveRetryCount", integer())
+                    optional("keepAliveRetryCount", integer()),
+                    atLeastOne("keepAliveIdleTimeSeconds",
+                            "keepAliveIntervalSeconds",
+                            "keepAliveRetryCount")
             ))
     );
 

--- a/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
+++ b/components/proxy/src/main/java/com/hotels/styx/routing/handlers/HostProxy.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2022 Expedia Inc.
+  Copyright (C) 2013-2023 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -26,7 +26,9 @@ import com.hotels.styx.api.LiveHttpResponse;
 import com.hotels.styx.api.ResponseEventListener;
 import com.hotels.styx.api.extension.Origin;
 import com.hotels.styx.api.extension.service.ConnectionPoolSettings;
+import com.hotels.styx.api.extension.service.TcpKeepAliveSettings;
 import com.hotels.styx.api.extension.service.TlsSettings;
+import com.hotels.styx.client.ChannelOptionSetting;
 import com.hotels.styx.client.Connection;
 import com.hotels.styx.client.OriginStatsFactory;
 import com.hotels.styx.client.StyxHostHttpClient;
@@ -41,8 +43,14 @@ import com.hotels.styx.metrics.CentralisedMetrics;
 import com.hotels.styx.routing.RoutingObject;
 import com.hotels.styx.routing.config.RoutingObjectFactory;
 import com.hotels.styx.routing.config.StyxObjectDefinition;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
+import io.netty.channel.socket.nio.NioChannelOption;
+import jdk.net.ExtendedSocketOptions;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -63,6 +71,7 @@ import static com.hotels.styx.routing.config.RoutingSupport.missingAttributeErro
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 /**
@@ -109,7 +118,12 @@ public class HostProxy implements RoutingObject {
             optional("maxHeaderSize", integer()),
             optional("metricPrefix", string()),
             optional("executor", string()),
-            optional("overrideHostHeader", bool())
+            optional("overrideHostHeader", bool()),
+            optional("tcpKeepAliveSettings", object(
+                    optional("keepAliveIdleTimeSeconds", integer()),
+                    optional("keepAliveIntervalSeconds", integer()),
+                    optional("keepAliveRetryCount", integer())
+            ))
     );
 
     private final String errorMessage;
@@ -176,6 +190,7 @@ public class HostProxy implements RoutingObject {
         private final String metricPrefix;
         private final String executor;
         private final boolean overrideHostHeader;
+        private final TcpKeepAliveSettings tcpKeepAliveSettings;
 
         public HostProxyConfiguration(
                 String host,
@@ -185,7 +200,8 @@ public class HostProxy implements RoutingObject {
                 int maxHeaderSize,
                 String metricPrefix,
                 String executor,
-                boolean overrideHostHeader) {
+                boolean overrideHostHeader,
+                TcpKeepAliveSettings tcpKeepAliveSettings) {
             this.host = host;
             this.connectionPool = connectionPool;
             this.tlsSettings = tlsSettings;
@@ -194,6 +210,7 @@ public class HostProxy implements RoutingObject {
             this.metricPrefix = metricPrefix;
             this.executor = executor;
             this.overrideHostHeader = overrideHostHeader;
+            this.tcpKeepAliveSettings = tcpKeepAliveSettings;
         }
 
         @JsonProperty("host")
@@ -236,6 +253,10 @@ public class HostProxy implements RoutingObject {
             return overrideHostHeader;
         }
 
+        @JsonProperty("tcpKeepAliveSettings")
+        public TcpKeepAliveSettings tcpKeepAliveSettings() {
+            return tcpKeepAliveSettings;
+        }
     }
 
     /**
@@ -285,6 +306,9 @@ public class HostProxy implements RoutingObject {
 
             boolean overrideHostHeader = config.get("overrideHostHeader", Boolean.class).orElse(false);
 
+            TcpKeepAliveSettings tcpKeepAliveSettings = config.get("tcpKeepAliveSettings", TcpKeepAliveSettings.class)
+                    .orElse(null);
+
             return createHostProxyHandler(
                     executor,
                     context.environment().centralisedMetrics(),
@@ -295,7 +319,8 @@ public class HostProxy implements RoutingObject {
                     maxHeaderSize,
                     metricPrefix,
                     objectName,
-                    overrideHostHeader);
+                    overrideHostHeader,
+                    tcpKeepAliveSettings);
         }
 
         private static HostAndPort addDefaultPort(HostAndPort hostAndPort, TlsSettings tlsSettings) {
@@ -321,7 +346,8 @@ public class HostProxy implements RoutingObject {
                 int maxHeaderSize,
                 String appId,
                 String originId,
-                boolean overrideHostHeader) {
+                boolean overrideHostHeader,
+                TcpKeepAliveSettings tcpKeepAliveSettings) {
 
             String host = hostAndPort.getHost();
             int port = hostAndPort.getPort();
@@ -333,6 +359,9 @@ public class HostProxy implements RoutingObject {
 
             OriginMetrics originMetrics = new OriginMetrics(metrics, origin);
 
+            Iterable<ChannelOptionSetting<?>> channelOptionSettings =
+                extractChannelOptionSettings(tcpKeepAliveSettings);
+
             ConnectionPool.Factory connectionPoolFactory = new SimpleConnectionPoolFactory.Builder()
                     .connectionFactory(
                             connectionFactory(
@@ -341,7 +370,8 @@ public class HostProxy implements RoutingObject {
                                     responseTimeoutMillis,
                                     maxHeaderSize,
                                     theOrigin -> originMetrics,
-                                    poolSettings.connectionExpirationSeconds()))
+                                    poolSettings.connectionExpirationSeconds(),
+                                    channelOptionSettings))
                     .connectionPoolSettings(poolSettings)
                     .metrics(metrics)
                     .build();
@@ -358,7 +388,8 @@ public class HostProxy implements RoutingObject {
                 int responseTimeoutMillis,
                 int maxHeaderSize,
                 OriginStatsFactory originStatsFactory,
-                long connectionExpiration) {
+                long connectionExpiration,
+                Iterable<ChannelOptionSetting<?>> channelOptionSettings) {
 
             // Uses the default executor for now:
             NettyConnectionFactory factory = new NettyConnectionFactory.Builder()
@@ -371,7 +402,10 @@ public class HostProxy implements RoutingObject {
                     )
                     .executor(executor)
                     .tlsSettings(tlsSettings)
-                    .httpConfig(newHttpConfigBuilder().setMaxHeadersSize(maxHeaderSize).build())
+                    .httpConfig(newHttpConfigBuilder()
+                        .setMaxHeadersSize(maxHeaderSize)
+                        .setSettings(channelOptionSettings)
+                        .build())
                     .build();
 
             if (connectionExpiration > 0) {
@@ -379,6 +413,37 @@ public class HostProxy implements RoutingObject {
             } else {
                 return factory;
             }
+        }
+
+        private static Iterable<ChannelOptionSetting<?>> extractChannelOptionSettings(TcpKeepAliveSettings tcpKeepAliveSettings) {
+            List<ChannelOptionSetting<?>> channelOptionSettings = new ArrayList<>();
+
+            if (tcpKeepAliveSettings != null) {
+                ChannelOption<Integer> tcpKeepIdle;
+                ChannelOption<Integer> tcpKeepInterval;
+                ChannelOption<Integer> tcpKeepRetryCount;
+                if (Epoll.isAvailable()) {
+                    tcpKeepIdle = EpollChannelOption.TCP_KEEPIDLE;
+                    tcpKeepInterval = EpollChannelOption.TCP_KEEPINTVL;
+                    tcpKeepRetryCount = EpollChannelOption.TCP_KEEPCNT;
+                } else {
+                    tcpKeepIdle = NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE);
+                    tcpKeepInterval = NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPINTERVAL);
+                    tcpKeepRetryCount = NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT);
+                }
+
+                ofNullable(tcpKeepAliveSettings.keepAliveIdleTimeSeconds())
+                    .ifPresent(keepIdleTime ->
+                        channelOptionSettings.add(new ChannelOptionSetting<>(tcpKeepIdle, keepIdleTime)));
+                ofNullable(tcpKeepAliveSettings.keepAliveIntervalSeconds())
+                    .ifPresent(interval ->
+                        channelOptionSettings.add(new ChannelOptionSetting<>(tcpKeepInterval, interval)));
+                ofNullable(tcpKeepAliveSettings.keepAliveRetryCount())
+                    .ifPresent(count ->
+                        channelOptionSettings.add(new ChannelOptionSetting<>(tcpKeepRetryCount, count)));
+            }
+
+            return channelOptionSettings;
         }
 
     }

--- a/components/proxy/src/main/kotlin/com/hotels/styx/infrastructure/configuration/json/mixins/TcpKeepAliveSettingsMixin.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/infrastructure/configuration/json/mixins/TcpKeepAliveSettingsMixin.kt
@@ -1,0 +1,51 @@
+/*
+  Copyright (C) 2013-2023 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.infrastructure.configuration.json.mixins
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder
+import com.hotels.styx.api.extension.service.TcpKeepAliveSettings
+
+/**
+ * Jackson annotations for [TcpKeepAliveSettings].
+ */
+@JsonDeserialize(builder = TcpKeepAliveSettings.Builder::class)
+interface TcpKeepAliveSettingsMixin {
+    @JsonProperty("keepAliveIdleTimeSeconds")
+    fun keepAliveIdleTimeSeconds(): Int?
+
+    @JsonProperty("keepAliveIntervalSeconds")
+    fun keepAliveIntervalSeconds(): Int?
+
+    @JsonProperty("keepAliveRetryCount")
+    fun keepAliveRetryCount(): Int?
+
+    /**
+     * The builder for TcpKeepAliveSettings.
+     */
+    @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+    interface Builder {
+        @JsonProperty("keepAliveIdleTimeSeconds")
+        fun keepAliveIdleTimeSeconds(keepAliveIdleTimeSeconds: Int): Builder
+
+        @JsonProperty("keepAliveIntervalSeconds")
+        fun keepAliveIntervalSeconds(keepAliveIntervalSeconds: Int): Builder
+
+        @JsonProperty("keepAliveRetryCount")
+        fun keepAliveRetryCount(keepAliveRetryCount: Int): Builder
+    }
+}

--- a/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsConfigConverter.kt
+++ b/components/proxy/src/main/kotlin/com/hotels/styx/services/OriginsConfigConverter.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2022 Expedia Inc.
+  Copyright (C) 2013-2023 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import com.hotels.styx.api.extension.service.BackendService
 import com.hotels.styx.api.extension.service.ConnectionPoolSettings
 import com.hotels.styx.api.extension.service.HealthCheckConfig
 import com.hotels.styx.api.extension.service.StickySessionConfig
+import com.hotels.styx.api.extension.service.TcpKeepAliveSettings
 import com.hotels.styx.api.extension.service.TlsSettings
 import com.hotels.styx.infrastructure.configuration.ConfigurationParser
 import com.hotels.styx.infrastructure.configuration.ConfigurationSource.configSource
@@ -145,7 +146,8 @@ internal class OriginsConfigConverter(
                         app.maxHeaderSize(),
                         origin,
                         "origins",
-                        app.isOverrideHostHeader()))
+                        app.isOverrideHostHeader(),
+                        app.tcpKeepAliveSettings()))
     }
 
     private fun hostProxyConfig(poolSettings: ConnectionPoolSettings,
@@ -154,7 +156,8 @@ internal class OriginsConfigConverter(
                                 maxHeaderSize: Int,
                                 origin: Origin,
                                 metricsPrefix: String,
-                                overrideHostHeader: Boolean): JsonNode = MAPPER.valueToTree(
+                                overrideHostHeader: Boolean,
+                                tcpKeepAliveSettings: TcpKeepAliveSettings?): JsonNode = MAPPER.valueToTree(
             HostProxyConfiguration(
                     "${origin.host()}:${origin.port()}",
                     poolSettings,
@@ -163,7 +166,8 @@ internal class OriginsConfigConverter(
                     maxHeaderSize,
                     metricsPrefix,
                     executor,
-                    overrideHostHeader))
+                    overrideHostHeader,
+                    tcpKeepAliveSettings))
 
     companion object {
         val LOGGER = LoggerFactory.getLogger(this::class.java)

--- a/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
+++ b/components/proxy/src/test/kotlin/com/hotels/styx/services/YamlFileConfigurationServiceTest.kt
@@ -448,6 +448,7 @@ class YamlFileConfigurationServiceTest : FunSpec() {
                 eventually(2.seconds, AssertionError::class.java) {
                     objectStore.get("app.app2").isPresent shouldBe true
                     objectStore.get("app.app2").get().let {
+                        it.config.get("tcpKeepAliveSettings").isObject shouldBe true
                         it.config.get("tcpKeepAliveSettings", TcpKeepAliveSettings::class.java)
                             .apply {
                                 keepAliveIdleTimeSeconds shouldBe 120

--- a/components/server/src/main/kotlin/com/hotels/styx/server/netty/codec/UrlDecoder.kt
+++ b/components/server/src/main/kotlin/com/hotels/styx/server/netty/codec/UrlDecoder.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2022 Expedia Inc.
+  Copyright (C) 2013-2023 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import com.hotels.styx.api.HttpHeaderNames.HOST
 import com.hotels.styx.api.Url
 import com.hotels.styx.api.Url.Builder.url
 import io.netty.handler.codec.http.HttpRequest
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.net.URI
 
 object UrlDecoder {
@@ -32,7 +32,7 @@ object UrlDecoder {
             val uri = try {
                 URI.create(encodedUrl)
             } catch (e: IllegalArgumentException) {
-                HttpUrl.parse(encodedUrl)!!.uri()
+                encodedUrl.toHttpUrlOrNull()!!.toUri()
             }
             Url.Builder()
                 .path(uri.rawPath)

--- a/docs/user-guide/configure-origins.md
+++ b/docs/user-guide/configure-origins.md
@@ -2,7 +2,7 @@
 
 ## Configuration file
 
-Backend services and origins known to Styx are configured in their own YAML file, which is referenced by the main 
+Backend services and origins known to Styx are configured in their own YAML file, which is referenced by the main
 configuration via the `originsFile` property in the services block.
 
 The value for this `originsFile` property accepts including environment variables (with the ${ENV_VAR} format) and can reference:
@@ -26,7 +26,7 @@ services:
       class: "com.hotels.styx.proxy.backends.file.FileBackedBackendServicesRegistry$Factory"
       config: {originsFile: "classpath:/conf/origins.yaml"}
  ```
-    
+
 ## Backend services
 
 Each service has the following properties:
@@ -50,6 +50,8 @@ Defaults to 60000 milliseconds.
 * **sslSettings**: Enables HTTPS for backend.
 
 * **overrideHostHeader**: send the origin host as the Host header instead of the incoming Host header, defaults to false.
+
+* **tcpKeepAliveSettings**: configuration for TCP connection keepalive, which can be set to programmatically modified the default behaviours of different OS.
 
 ## Health check
 See [Health Checks](configure-health-checks.md) for details.
@@ -121,12 +123,21 @@ The `tlsSettings` is an optional configuration block. If present, it enables an 
 
 *   **trustStorePassword** - Password for keystore referred by **trustStorePath** attribute.
 
-Styx considers incoming traffic and outgoing traffic separately. It will convert between the HTTP and HTTPS protocols 
+Styx considers incoming traffic and outgoing traffic separately. It will convert between the HTTP and HTTPS protocols
 when the incoming server side protocol differs from the outgoing origin side protocol.
 
 Limitations:
 
 *   Styx does not support client side authentication for backend origins. Therefore the backend origins are unable to authenticate styx.
+
+## TCP KeepAlive Settings
+
+By default, Linux has `tcp_keepalive_time` set to 7200 seconds, `tcp_keepalive_probes` set to 9, and `tcp_keepalive_intvl` set to 75 seconds.
+The values can be modified programmatically by the follow properties:
+
+*   **keepAliveIdleTimeSeconds**: Determines the frequency of sending the TCP keepalive packets to keep a connection alive if it is currently unused. This value is used only when keepalive is enabled.
+*   **keepAliveIntervalSeconds**: Determines the frequency of sending TCP keepalive probes before deciding a broken connection.
+*   **keepAliveRetryCount**: Determines the duration for a reply for each keepalive probe. This value is important to calculate the time before your connection has a keepalive death.
 
 ## Origins
 
@@ -148,7 +159,7 @@ Here is the configuration for an example backend service:
         uri: "/version.txt"
         intervalMillis: 10000
         healthyThreshold: 2
-        unhealthyThreshold: 2  
+        unhealthyThreshold: 2
       stickySession:
         enabled: true
         timeoutSeconds: 14321
@@ -156,7 +167,7 @@ Here is the configuration for an example backend service:
         maxConnectionsPerHost: 300
         maxPendingConnectionsPerHost: 50
         connectTimeoutMillis: 12000
-        pendingConnectionTimeoutMillis: 10000    
+        pendingConnectionTimeoutMillis: 10000
       rewrites:
       - urlPattern: "/hwa/(.*)/foobar/(.*)"
         replacement: "/$1/barfoo/$2"
@@ -176,4 +187,8 @@ Here is the configuration for an example backend service:
       - id: "hwa1"
         host: "chhlapputle2e63.karmalab.net:7401"
       overrideHostHeader: true
+      tcpKeepAliveSettings:
+        keepAliveIdleTimeSeconds: 120
+        keepAliveIntervalSeconds: 30
+        keepAliveRetryCount: 3
 ```


### PR DESCRIPTION
### :pencil: Description
The connection was dropped by servers in the upstream. We need to tweak the TCP keepalive idle time on Styx to make it send heartbeat to upstream to reset the TCP connection idle timeout before the upstream drops the connection.

Linux has TCP_KEEPALIVE_IDLE_TIME set to 7200 seconds by default. We need to set this to smaller than the idle timeout of server/upstream to avoid TransportLostException.

---
I found it a bit hard to write tests for this scenario as we have to simulate a connection idle timeout on the server side/upstream and our current test utility for mocked http server (WireMockServer) doesn’t allow us to modify the idle timeout.
