### PR TITLE
feat: increment responsesByStatus metric when Styx returns 408 Request Timeout

### DIFF
--- a/components/proxy/src/main/java/com/hotels/styx/proxy/HttpErrorStatusMetrics.java
+++ b/components/proxy/src/main/java/com/hotels/styx/proxy/HttpErrorStatusMetrics.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2023 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.net.InetSocketAddress;
 
 import static com.hotels.styx.api.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static com.hotels.styx.api.HttpResponseStatus.REQUEST_TIMEOUT;
 import static com.hotels.styx.proxy.ExceptionMetricsKt.countBackendFault;
 import static java.util.Objects.requireNonNull;
 
@@ -79,6 +80,8 @@ public class HttpErrorStatusMetrics implements HttpErrorStatusListener {
         if (!(cause instanceof PluginException)) {
             if (INTERNAL_SERVER_ERROR.equals(status)) {
                 metrics.proxy().styxErrors().increment();
+            } else if (REQUEST_TIMEOUT.equals(status)) {
+                metrics.proxy().server().responsesByStatus(status.code()).increment();
             } else if (status != null && status.code() > 500) {
                 countBackendFault(metrics, cause);
             }

--- a/components/server/src/main/java/com/hotels/styx/server/netty/handlers/RequestTimeoutHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/handlers/RequestTimeoutHandler.java
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2021 Expedia Inc.
+  Copyright (C) 2013-2023 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class RequestTimeoutHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        if (msg instanceof HttpRequest && ((HttpRequest) msg).getDecoderResult().isSuccess()) {
+        if (msg instanceof HttpRequest && ((HttpRequest) msg).decoderResult().isSuccess()) {
             requestOngoing = true;
             this.msg = msg;
         } else if (msg instanceof LastHttpContent) {
@@ -47,7 +47,7 @@ public class RequestTimeoutHandler extends ChannelInboundHandlerAdapter {
         if (evt instanceof IdleStateEvent) {
             IdleStateEvent e = (IdleStateEvent) evt;
             if (e.state() == IdleState.READER_IDLE && requestOngoing) {
-                throw new RequestTimeoutException("message=" + String.valueOf(msg));
+                throw new RequestTimeoutException("message=" + msg);
             }
         }
 


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
Currently when Styx itself returns a "408 Request Timeout" response, currently it does not increment the `responsesByStatus` metric, as the `HttpPipelineHandler`'s `handleChannelException` method directly calls the respondAndClose method.

This change updates the `HttpErrorStatusMetrics` which is a `HttpErrorStatusListener` to increment the metric if the response status is a 408 Request Timeout

I've also made a few code cleanup changes

