### PR TITLE
fix: failed timer key check

### DIFF
--- a/components/common/src/main/kotlin/com/hotels/styx/metrics/ContextualTimers.kt
+++ b/components/common/src/main/kotlin/com/hotels/styx/metrics/ContextualTimers.kt
@@ -33,8 +33,9 @@ class ContextualTimers {
      * @param timerPurpose encapsulates the relevant metric
      */
     fun startTiming(centralisedMetrics: CentralisedMetrics, timerPurpose: TimerPurpose) {
-        check(!stoppers.containsKey(timerPurpose))
-        stoppers[timerPurpose] = timerPurpose.timerMetric(centralisedMetrics).startTiming()
+        if (!stoppers.containsKey(timerPurpose)) {
+            stoppers[timerPurpose] = timerPurpose.timerMetric(centralisedMetrics).startTiming()
+        }
     }
 
     /**


### PR DESCRIPTION
To fix the following exception
```
[exceptionClass=com.hotels.styx.metrics.ContextualTimers, exceptionMethod=startTiming, exceptionID=d90016b4]
java.lang.IllegalStateException: Check failed.
	at com.hotels.styx.metrics.ContextualTimers.startTiming(ContextualTimers.kt:36)
	at com.hotels.styx.client.connectionpool.LatencyTiming.startResponseTiming(LatencyTiming.kt:51)
	at com.hotels.styx.client.netty.connectionpool.HttpRequestOperation.lambda$execute$2(HttpRequestOperation.java:149)
```
