### PR TITLE
fix: handling subscription cancllation on response

### DIFF
--- a/components/client/src/main/kotlin/com/hotels/styx/client/ResponseCancelledException.kt
+++ b/components/client/src/main/kotlin/com/hotels/styx/client/ResponseCancelledException.kt
@@ -1,0 +1,21 @@
+/*
+  Copyright (C) 2013-2023 Expedia Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package com.hotels.styx.client
+
+/**
+ * An exception to be thrown when a subscription to a response is cancelled.
+ */
+class ResponseCancelledException : RuntimeException("Subscription to the response was cancelled")

--- a/components/server/src/main/kotlin/com/hotels/styx/server/netty/connectors/StyxExceptionToHttpStatus.kt
+++ b/components/server/src/main/kotlin/com/hotels/styx/server/netty/connectors/StyxExceptionToHttpStatus.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2013-2022 Expedia Inc.
+  Copyright (C) 2013-2023 Expedia Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import com.hotels.styx.api.exceptions.OriginUnreachableException
 import com.hotels.styx.api.exceptions.ResponseTimeoutException
 import com.hotels.styx.api.exceptions.TransportLostException
 import com.hotels.styx.client.BadHttpResponseException
+import com.hotels.styx.client.ResponseCancelledException
 import com.hotels.styx.client.StyxClientException
 import com.hotels.styx.client.connectionpool.ResourceExhaustedException
 import com.hotels.styx.server.BadRequestException
@@ -47,7 +48,8 @@ object StyxExceptionToHttpStatus {
                 NoServiceConfiguredException::class.java,
                 BadHttpResponseException::class.java,
                 ContentOverflowException::class.java,
-                TransportLostException::class.java
+                TransportLostException::class.java,
+                ResponseCancelledException::class.java,
             )
             .add(SERVICE_UNAVAILABLE, ResourceExhaustedException::class.java)
             .add(GATEWAY_TIMEOUT, ResponseTimeoutException::class.java)


### PR DESCRIPTION
This is to fix cancellation happening on upstreams of reactive stream not being handled properly by the subscriber