### PR TITLE
feat: adding separated max connections setting for http2

### DIFF
--- a/components/api/src/main/kotlin/com/hotels/styx/api/extension/service/Http2ConnectionPoolSettings.kt
+++ b/components/api/src/main/kotlin/com/hotels/styx/api/extension/service/Http2ConnectionPoolSettings.kt
@@ -19,7 +19,8 @@ package com.hotels.styx.api.extension.service
  * Programmatically configurable HTTP/2 connection pool settings.
  */
 data class Http2ConnectionPoolSettings(
+    val maxConnections: Int? = 10,
     val minConnections: Int? = 1,
-    val maxStreamsPerConnection: Int? = 20,
+    val maxStreamsPerConnection: Int? = 1024,
     val maxPendingStreamsPerHost: Int? = 200,
 )

--- a/components/api/src/test/java/com/hotels/styx/api/extension/service/ConnectionPoolSettingsTest.java
+++ b/components/api/src/test/java/com/hotels/styx/api/extension/service/ConnectionPoolSettingsTest.java
@@ -25,13 +25,14 @@ import static org.hamcrest.Matchers.is;
 public class ConnectionPoolSettingsTest {
     @Test
     public void setsConfigurationValues() {
-        ConnectionPoolSettings config = new ConnectionPoolSettings(5, 8, 2345, 123, 1L, new Http2ConnectionPoolSettings(8, 7, 10));
+        ConnectionPoolSettings config = new ConnectionPoolSettings(10, 5, 8, 2345, 123, 1L, new Http2ConnectionPoolSettings(10, 8, 7, 10));
 
         assertThat(config.connectTimeoutMillis(), is(equalTo(2345)));
         assertThat(config.pendingConnectionTimeoutMillis(), is(equalTo(123)));
         assertThat(config.maxConnectionsPerHost(), is(equalTo(5)));
         assertThat(config.maxPendingConnectionsPerHost(), is(equalTo(8)));
         assertThat(config.connectionExpirationSeconds(), is(equalTo(1L)));
+        assertThat(config.http2ConnectionPoolSettings().getMaxConnections(), is(equalTo(10)));
         assertThat(config.http2ConnectionPoolSettings().getMinConnections(), is(equalTo(8)));
         assertThat(config.http2ConnectionPoolSettings().getMaxStreamsPerConnection(), is(equalTo(7)));
         assertThat(config.http2ConnectionPoolSettings().getMaxPendingStreamsPerHost(), is(equalTo(10)));
@@ -39,10 +40,10 @@ public class ConnectionPoolSettingsTest {
 
     @Test
     public void shouldBuildFromOtherPoolSettings() {
-        ConnectionPoolSettings config = new ConnectionPoolSettings(5, 8, 2345, 123, 1L, new Http2ConnectionPoolSettings(8, 7, 10));
+        ConnectionPoolSettings config = new ConnectionPoolSettings(5, 8, 2345, 123, 1L, new Http2ConnectionPoolSettings(10, 8, 7, 10));
         ConnectionPoolSettings newConfig = new ConnectionPoolSettings.Builder(config)
                 .connectTimeout(444, MILLISECONDS)
-                .http2ConnectionPoolSettings(new Http2ConnectionPoolSettings(4, 3, 8))
+                .http2ConnectionPoolSettings(new Http2ConnectionPoolSettings(10, 4, 3, 8))
                 .build();
 
         assertThat(newConfig.connectTimeoutMillis(), is(equalTo(444)));
@@ -50,6 +51,7 @@ public class ConnectionPoolSettingsTest {
         assertThat(newConfig.maxConnectionsPerHost(), is(equalTo(5)));
         assertThat(newConfig.maxPendingConnectionsPerHost(), is(equalTo(8)));
         assertThat(config.connectionExpirationSeconds(), is(equalTo(1L)));
+        assertThat(config.http2ConnectionPoolSettings().getMaxConnections(), is(equalTo(10)));
         assertThat(config.http2ConnectionPoolSettings().getMinConnections(), is(equalTo(4)));
         assertThat(config.http2ConnectionPoolSettings().getMaxStreamsPerConnection(), is(equalTo(3)));
         assertThat(config.http2ConnectionPoolSettings().getMaxPendingStreamsPerHost(), is(equalTo(8)));

--- a/components/api/src/test/kotlin/com.hotels.styx.api.extension/Http2ConnectionPoolSettingsTest.kt
+++ b/components/api/src/test/kotlin/com.hotels.styx.api.extension/Http2ConnectionPoolSettingsTest.kt
@@ -21,8 +21,9 @@ import io.kotlintest.specs.StringSpec
 
 class Http2ConnectionPoolSettingsTest : StringSpec({
     "setsConfigurationValues" {
-        val config = Http2ConnectionPoolSettings(5, 10, 20)
+        val config = Http2ConnectionPoolSettings(10, 5, 10, 20)
 
+        config.maxConnections shouldBe 10
         config.minConnections shouldBe 5
         config.maxStreamsPerConnection shouldBe 10
         config.maxPendingStreamsPerHost shouldBe 20

--- a/docs/user-guide/configure-connection-pooling.md
+++ b/docs/user-guide/configure-connection-pooling.md
@@ -42,9 +42,11 @@ expiration time if they do not serve any requests.
 
 * *http2ConnectionPoolSettings*: connection pool settings for http2.
 
+    *   **maxConnections** - the maximum number of connections that may be established to a single origin.
+
     *   *minConnections* - the minimum number of connections that may be established to a single origin.
 
-    *   *maxStreamsPerConnection* - the minimum number of streams that may be established to a single connection.
+  *   **maxStreamsPerConnection** - the minimum number of streams that may be established to a single connection. The minimum of this configuration and the remote peer configuration is taken.
 
     *   *maxPendingStreamsPerHost* - the maximum number of streams that may be waiting to be acquired at the same time.
 

--- a/docs/user-guide/configure-connection-pooling.md
+++ b/docs/user-guide/configure-connection-pooling.md
@@ -42,11 +42,11 @@ expiration time if they do not serve any requests.
 
 * *http2ConnectionPoolSettings*: connection pool settings for http2.
 
-    *   **maxConnections** - the maximum number of connections that may be established to a single origin.
+    *   *maxConnections* - the maximum number of connections that may be established to a single origin.
 
     *   *minConnections* - the minimum number of connections that may be established to a single origin.
 
-  *   **maxStreamsPerConnection** - the minimum number of streams that may be established to a single connection. The minimum of this configuration and the remote peer configuration is taken.
+    *   *maxStreamsPerConnection* - the minimum number of streams that may be established to a single connection. -1 means no limit. The minimum of this configuration and the remote peer configuration is taken.
 
     *   *maxPendingStreamsPerHost* - the maximum number of streams that may be waiting to be acquired at the same time.
 

--- a/docs/user-guide/configure-origins.md
+++ b/docs/user-guide/configure-origins.md
@@ -94,9 +94,11 @@ The connection pool block has the following properties:
 
 *   **http2ConnectionPoolSettings**: connection pool settings for http2.
 
+    *   **maxConnections** - the maximum number of connections that may be established to a single origin.
+
     *   **minConnections** - the minimum number of connections that may be established to a single origin.
 
-    *   **maxStreamsPerConnection** - the minimum number of streams that may be established to a single connection.
+    *   **maxStreamsPerConnection** - the minimum number of streams that may be established to a single connection. The minimum of this configuration and the remote peer configuration is taken.
 
     *   **maxPendingStreamsPerHost** - the maximum number of streams that may be waiting to be acquired at the same time.
 

--- a/docs/user-guide/configure-origins.md
+++ b/docs/user-guide/configure-origins.md
@@ -98,7 +98,7 @@ The connection pool block has the following properties:
 
     *   **minConnections** - the minimum number of connections that may be established to a single origin.
 
-    *   **maxStreamsPerConnection** - the minimum number of streams that may be established to a single connection. The minimum of this configuration and the remote peer configuration is taken.
+    *   **maxStreamsPerConnection** - the minimum number of streams that may be established to a single connection. -1 means no limit. The minimum of this configuration and the remote peer configuration is taken.
 
     *   **maxPendingStreamsPerHost** - the maximum number of streams that may be waiting to be acquired at the same time.
 


### PR DESCRIPTION
- another field for maxConnectionsPerHost just for http2
- modify default number of maxStreamsPerConnection