### PR TITLE
chore: always include amd linux and arm linux dependencies for netty dependencies and eliminate os based profiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 language: java
 jdk:
   - openjdk11
-script: mvn verify -Pquality,linux
+script: mvn verify -Pquality
 cache:
   directories:
   - "~/.m2/repository"

--- a/Makefile
+++ b/Makefile
@@ -21,20 +21,19 @@ clean:
 unit-test:
 	mvn clean test -Pquality
 
-PLATFORM=macosx
 ## Compile, run unit tests, checkstyle and integration tests
 e2e:
-	mvn clean verify -Pquality,release,$(PLATFORM)
+	mvn clean verify -Pquality,release
 
 ## Compile code and tests but do not run
 # Note: Pre-integration test phase is necessary to produce styx.properties file
 # needed by AdminSpec.scala tests.
 e2e-compile:
-	mvn clean pre-integration-test -P$(PLATFORM)
+	mvn clean pre-integration-test
 
 ## Run system tests
 e2e-test:
-	mvn -f system-tests/e2e-suite/pom.xml -P$(PLATFORM) scalatest:test
+	mvn -f system-tests/e2e-suite/pom.xml scalatest:test
 
 ## Execute a single end-to-end (scala) test
 # Alternatively, it should be possible to run an individual e2e test
@@ -47,11 +46,11 @@ e2e-test-single:
 
 ## Compile, test and create styx.zip
 release: clean
-	mvn install -Prelease,$(PLATFORM)
+	mvn install -Prelease
 
 ## Compile and create styx.zip without running tests
 release-no-tests: clean
-	mvn install -Prelease,$(PLATFORM) -Dmaven.test.skip=true
+	mvn install -Prelease -Dmaven.test.skip=true
 
 GIT_BRANCH=$(shell basename $(shell git symbolic-ref --short HEAD))
 LOAD_TEST_DIR=$(CURRENT_DIR)/logs/load-test-$(GIT_BRANCH)-$(shell date "+%Y_%m_%d_%H:%M:%S")
@@ -133,7 +132,7 @@ changelog:
 # Default configuration file: /styx/default-config/default.yml
 #
 docker-image: clean
-	mvn install -Prelease,linux,docker -DskipTests=true -Dmaven.test.skip=true
+	mvn install -Prelease,docker -DskipTests=true -Dmaven.test.skip=true
 
 ## Starts a "demo" mode of Styx that can be used to explore the features, or for manual testing.
 start-demo: release-styx

--- a/components/client/pom.xml
+++ b/components/client/pom.xml
@@ -23,7 +23,13 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <classifier>${netty-transport-native-epoll.classifier}</classifier>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-aarch_64</classifier>
     </dependency>
 
     <dependency>

--- a/components/common/pom.xml
+++ b/components/common/pom.xml
@@ -24,7 +24,13 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <classifier>${netty-transport-native-epoll.classifier}</classifier>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-aarch_64</classifier>
     </dependency>
 
     <dependency>

--- a/components/proxy/pom.xml
+++ b/components/proxy/pom.xml
@@ -43,7 +43,13 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <classifier>${netty-tcnative.classifier}</classifier>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <classifier>linux-aarch_64</classifier>
     </dependency>
 
     <dependency>

--- a/components/server/pom.xml
+++ b/components/server/pom.xml
@@ -43,7 +43,13 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <classifier>${netty-tcnative.classifier}</classifier>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <classifier>linux-aarch_64</classifier>
     </dependency>
 
     <dependency>

--- a/components/test-api/pom.xml
+++ b/components/test-api/pom.xml
@@ -36,9 +36,14 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <classifier>${netty-tcnative.classifier}</classifier>
+      <classifier>linux-x86_64</classifier>
     </dependency>
 
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <classifier>linux-aarch_64</classifier>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -14,7 +14,7 @@
 
 
   <properties>
-    <artifact.finalName>styx-${project.version}-${netty-tcnative.classifier}</artifact.finalName>
+    <artifact.finalName>styx-${project.version}</artifact.finalName>
     <distribution.dir>${project.basedir}/target</distribution.dir>
     <main.basedir>${project.parent.basedir}</main.basedir>
     <skipCheckstyle>true</skipCheckstyle>
@@ -100,7 +100,6 @@
               <groupId>com.hotels.styx</groupId>
               <artifactId>styx</artifactId>
               <version>${project.version}</version>
-              <classifier>${netty-tcnative.classifier}</classifier>
               <packaging>zip</packaging>
               <generatePom>false</generatePom>
             </configuration>
@@ -131,7 +130,6 @@
               <groupId>com.hotels.styx</groupId>
               <artifactId>styx</artifactId>
               <version>${project.version}</version>
-              <classifier>${netty-tcnative.classifier}</classifier>
               <packaging>zip</packaging>
               <generatePom>false</generatePom>
             </configuration>

--- a/docker/styx-image/Dockerfile
+++ b/docker/styx-image/Dockerfile
@@ -2,7 +2,7 @@ ARG TAG=11-jdk
 FROM openjdk:${TAG}
 
 ARG STYX_VERSION=""
-ARG STYX_IMAGE=https://github.com/HotelsDotCom/styx/releases/download/${STYX_VERSION}/${STYX_VERSION}-linux-x86_64.zip
+ARG STYX_IMAGE=https://github.com/HotelsDotCom/styx/releases/download/${STYX_VERSION}/${STYX_VERSION}.zip
 
 ENV APP_HOME=/styx
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -21,13 +21,9 @@ To clone and build styx afresh:
 
     $ git clone https://github.com/HotelsDotCom/styx.git
     $ cd styx
-    $ make release-no-tests PLATFORM=macosx
+    $ make release-no-tests
 
-This produces a file `distribution/target/styx.zip`. This build is for MacOSX.
-The *PLATFORM* argument defaults to *macosx*.
-To build for Linux, you need to override a *PLATFORM* argument, like so:
-
-    $ make release-no-tests PLATFORM=linux
+This produces a file `distribution/target/styx.zip`.
 
 If `styx-test/` already exists, remove it first to avoid conflicts on dependencies:
 
@@ -35,7 +31,7 @@ If `styx-test/` already exists, remove it first to avoid conflicts on dependenci
 
 Let's unzip this file:
 
-    $ unzip distribution/target/styx-<VERSION>-<OS>-<PLATFORM>.zip -d styx-test
+    $ unzip distribution/target/styx-<VERSION>.zip -d styx-test
 
 
 ## 1.4 Running Styx

--- a/pom.xml
+++ b/pom.xml
@@ -102,9 +102,6 @@
     <java.testSource>11</java.testSource>
     <java.testTarget>11</java.testTarget>
 
-    <!-- Build defaults to linux platform: -->
-    <netty-tcnative.classifier>linux-x86_64</netty-tcnative.classifier>
-
     <!-- General Versions -->
     <guava.version>32.0.0-jre</guava.version>
     <jackson.version>2.13.2</jackson.version>
@@ -115,14 +112,14 @@
     <dropwizard.version>4.2.4</dropwizard.version>
     <micrometer.version>1.8.0</micrometer.version>
     <antlr.version>4.5.1-1</antlr.version>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.version>4.1.96.Final</netty.version>
 
-    <netty-tcnative.version>2.0.48.Final</netty-tcnative.version>
+    <netty-tcnative.version>2.0.61.Final</netty-tcnative.version>
     <rxjava.version>1.1.6</rxjava.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <reactor.version>3.4.16</reactor.version>
     <pcollections.version>3.0.3</pcollections.version>
-    <bytebuddy.version>1.10.6</bytebuddy.version>
+    <bytebuddy.version>1.14.7</bytebuddy.version>
 
     <!--Kotlin -->
     <kotlin.version>1.6.10</kotlin.version>
@@ -198,13 +195,21 @@
 
     <surefire.skip.tests>false</surefire.skip.tests>
 
-    <netty-transport-native-epoll.classifier/>
     <rxjava-reactive-streams.version>1.1.1</rxjava-reactive-streams.version>
     <mockk.version>1.9.3</mockk.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <!-- Netty -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <groupId>com.hotels.styx</groupId>
         <artifactId>styx-api</artifactId>
@@ -233,29 +238,6 @@
         <groupId>com.hotels.styx</groupId>
         <artifactId>styx-proxy</artifactId>
         <version>${project.version}</version>
-      </dependency>
-
-      <!-- Netty -->
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-native-epoll</artifactId>
-        <version>${netty.version}</version>
-        <classifier>${netty-transport-native-epoll.classifier}</classifier>
-      </dependency>
-
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>${netty-tcnative.version}</version>
-        <classifier>${netty-tcnative.classifier}</classifier>
       </dependency>
 
       <!-- RxJava -->
@@ -1064,23 +1046,6 @@
   </build>
 
   <profiles>
-    <!-- profile for linux -->
-    <profile>
-      <id>linux</id>
-      <properties>
-        <netty-transport-native-epoll.classifier>linux-x86_64</netty-transport-native-epoll.classifier>
-        <netty-tcnative.classifier>linux-x86_64</netty-tcnative.classifier>
-      </properties>
-    </profile>
-
-    <!-- profile for mac os -->
-    <profile>
-      <id>macosx</id>
-      <properties>
-        <netty-tcnative.classifier>osx-x86_64</netty-tcnative.classifier>
-      </properties>
-    </profile>
-
     <profile>
       <id>release</id>
       <modules>

--- a/system-tests/docker-test-env/README.md
+++ b/system-tests/docker-test-env/README.md
@@ -22,7 +22,7 @@ $ brew install toxiproxy
 First, build a development Docker image for Styx:
 
 ```bash
-$ mvn install -Prelease,linux -Dmaven.test.skip=true
+$ mvn install -Prelease -Dmaven.test.skip=true
 $ make docker-image
 ``` 
 

--- a/travis/deploy.sh
+++ b/travis/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013-2021 Expedia Inc.
+# Copyright (C) 2013-2023 Expedia Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,19 +36,19 @@ echo "Deploying Release to sonatype and docker hub"
 #Ensure a correct version was configured in the pom files.
 mvn versions:set -DnewVersion=$TRAVIS_TAG
 #Deploy to sonatype
-mvn deploy --settings travis/mvn-settings.xml -B -U -P sonatype-oss-release,linux -DskipTests=true -Dmaven.test.skip=true
+mvn deploy --settings travis/mvn-settings.xml -B -U -P sonatype-oss-release -DskipTests=true -Dmaven.test.skip=true
 #Deploy to dockerhub
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 mvn install -f distribution/pom.xml -B -U -P docker -Dstyxcore.docker.image=hotelsdotcom/styx
 docker push hotelsdotcom/styx
 
-#Prepare macosx bundle for github releases
-mvn install -B -U -P macosx,release -DskipTests=true -Dmaven.test.skip=true -Dgpg.skip=true
+#Prepare bundle for github releases
+mvn install -B -U -P release -DskipTests=true -Dmaven.test.skip=true -Dgpg.skip=true
 }
 
 function deploySnapshot() {
   echo "Deploying snapshot to sonatype"
-  mvn deploy --settings travis/mvn-settings.xml -B -U -P sonatype-oss-release,linux -DskipTests=true -Dmaven.test.skip=true -Dgpg.skip=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  mvn deploy --settings travis/mvn-settings.xml -B -U -P sonatype-oss-release -DskipTests=true -Dmaven.test.skip=true -Dgpg.skip=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 }
 
 if [[ -n "$TRAVIS_TAG" ]]; then


### PR DESCRIPTION
This is mainly to fix epoll not available issue on ARM machines
macos won't be a problem because it should fallback to nio.
