### PR TITLE
fix(request context): removing context.clear() from hookFinally of re…

### DIFF
--- a/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
+++ b/components/server/src/main/java/com/hotels/styx/server/netty/connectors/HttpPipelineHandler.java
@@ -278,8 +278,6 @@ public class HttpPipelineHandler extends SimpleChannelInboundHandler<LiveHttpReq
                 protected void hookFinally(SignalType type) {
                     timers.stopTiming(RESPONSE_PROCESSING);
                     timers.stopTiming(REQUEST_PROCESSING);
-
-                    context.clear();
                 }
             });
 


### PR DESCRIPTION
…quest stream and let users to decide where to call it
